### PR TITLE
Add test for CLI version output

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+"""
+Tests the SSWG CLI entrypoint.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "generator.main", "--version"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "SSWG Workflow Generator" in result.stdout


### PR DESCRIPTION
This test verifies that the CLI entrypoint returns the correct version information.

