### PR TITLE
Add clarity score upper bound tests

### DIFF
--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -9,4 +9,12 @@ from ai_evaluation.quality_metrics import evaluate_clarity
 def test_semantic_placeholder():
     wf = {"phases": [{"id": "P1", "ai_task_logic": "Analyze semantic similarity"}]}
     metrics = evaluate_clarity(wf)
-    assert metrics["clarity_score"] >= 0
+    assert 0 <= metrics["clarity_score"] <= 1
+
+
+def test_clarity_clamped_to_upper_bound():
+    long_text = " ".join(["detailed"] * 50)
+    wf = {"phases": [{"id": "P1", "ai_task_logic": long_text}]}
+    metrics = evaluate_clarity(wf)
+
+    assert metrics["clarity_score"] == 1.0


### PR DESCRIPTION
## Summary
- ensure clarity_score is asserted to stay within 0-1 bounds
- add long ai_task_logic scenario to confirm clarity score clamps at 1.0

## Testing
- pytest tests/test_semantics.py

-----