### PR TITLE
Handle id in default phase selection

### DIFF
--- a/ai_core/workflow.py
+++ b/ai_core/workflow.py
@@ -125,7 +125,7 @@ class Workflow:
         Return the default ordered list of phase identifiers.
 
         For schema-based workflows:
-        - If `phases` contains dicts with `phase_id` fields, use those.
+        - If `phases` contains dicts with `id`/`phase_id`/`name` fields, use those.
 
         For legacy workflows:
         - Fall back to the original hard-coded phases.
@@ -133,7 +133,7 @@ class Workflow:
         if self.phases:
             ids: List[str] = []
             for ph in self.phases:
-                pid = ph.get("phase_id") or ph.get("name")
+                pid = ph.get("id") or ph.get("phase_id") or ph.get("name")
                 if pid:
                     ids.append(str(pid))
             if ids:

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -5,6 +5,7 @@ through generation → validation → evaluation → export.
 """
 
 from ai_core.orchestrator import Orchestrator
+from ai_core.workflow import Workflow
 from ai_validation.schema_validator import validate_workflow
 from ai_evaluation.quality_metrics import evaluate_clarity
 from ai_visualization.export_manager import export_workflow
@@ -24,3 +25,17 @@ def test_full_workflow_cycle(tmp_path):
     exports = export_workflow(wf, export_mode="json")
     for f in exports.values():
         assert os.path.exists(f)
+
+
+def test_get_default_phases_prefers_id():
+    wf = Workflow(
+        {
+            "phases": [
+                {"id": "alpha"},
+                {"phase_id": "beta"},
+                {"name": "gamma"},
+            ]
+        }
+    )
+
+    assert wf.get_default_phases() == ["alpha", "beta", "gamma"]


### PR DESCRIPTION
## Summary
- prefer `id` when collecting default phase identifiers, with fallbacks to `phase_id` and `name`
- document the supported phase identifier keys in `Workflow.get_default_phases`
- add a unit test covering workflows whose phases define `id`

## Testing
- `pytest tests/test_workflow.py::test_get_default_phases_prefers_id`


------