### PR TITLE
Add LLM refinement contract to recursion manager

### DIFF
--- a/modules/llm_adapter.py
+++ b/modules/llm_adapter.py
@@ -1,1 +1,161 @@
-from llm_adapter import generate_text
+"""LLM adapter for recursion-aware refinement.
+
+This module defines the contract for LLM-in-the-loop refinement and exposes
+helpers for building prompts and parsing responses.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, Mapping, Optional
+
+logger = logging.getLogger("modules.llm_adapter")
+
+
+@dataclass(frozen=True)
+class RefinementContract:
+    """Structured contract for LLM-driven refinement outputs.
+
+    The contract is intentionally strict so downstream consumers can rely on
+    deterministic keys and formats.
+
+    Fields expected from the model:
+    - ``decision``: one of ``{"accept", "revise", "stop"}``
+    - ``refined_workflow``: JSON object representing workflow deltas or a fully
+      rewritten workflow. Must be an object/dict.
+    - ``reasoning``: short natural-language explanation of the decision.
+    - ``confidence``: numeric confidence score (0-1 range recommended).
+    - ``score_delta``: numeric delta describing expected improvement.
+    """
+
+    version: str = "2024-06"
+    required_fields: tuple[str, ...] = (
+        "decision",
+        "refined_workflow",
+        "reasoning",
+        "confidence",
+        "score_delta",
+    )
+    allowed_decisions: tuple[str, ...] = ("accept", "revise", "stop")
+    format: str = "json"
+
+    @property
+    def system_prompt(self) -> str:
+        """System prompt describing the response contract."""
+
+        return (
+            "You are a workflow refinement model. Respond strictly with JSON that "
+            "matches the contract fields: decision (accept|revise|stop), "
+            "refined_workflow (object), reasoning (string), confidence (number), "
+            "and score_delta (number). Do not include any extra keys or prose."
+        )
+
+    def describe(self) -> str:
+        """Render a short description of the contract."""
+
+        required = ", ".join(self.required_fields)
+        decisions = ", ".join(self.allowed_decisions)
+        return (
+            f"Contract v{self.version} expects JSON with fields [{required}] "
+            f"and decision in {{{decisions}}}."
+        )
+
+
+def build_refinement_prompt(
+    workflow_data: Mapping[str, Any],
+    evaluation_report: Mapping[str, Any],
+    depth: int,
+    contract: Optional[RefinementContract] = None,
+) -> str:
+    """Build a compact prompt for the refinement LLM.
+
+    The prompt contains:
+    - Current recursion depth
+    - Workflow summary
+    - Latest evaluation findings
+    - Explicit JSON contract reminder
+    """
+
+    active_contract = contract or RefinementContract()
+    workflow_summary = json.dumps(workflow_data, indent=2)
+    evaluation_summary = json.dumps(evaluation_report, indent=2)
+
+    return (
+        f"Recursion depth: {depth}.\n"
+        f"Workflow to refine (JSON):\n{workflow_summary}\n\n"
+        f"Latest evaluation (JSON):\n{evaluation_summary}\n\n"
+        f"Respond with JSON matching: {active_contract.describe()}"
+    )
+
+
+def parse_refinement_response(
+    raw_response: str, contract: Optional[RefinementContract] = None
+) -> Dict[str, Any]:
+    """Parse and validate the LLM refinement response.
+
+    Raises ``ValueError`` if parsing fails or required fields are missing.
+    """
+
+    active_contract = contract or RefinementContract()
+
+    try:
+        payload: Dict[str, Any] = json.loads(raw_response)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"LLM response is not valid JSON: {exc}") from exc
+
+    missing: Iterable[str] = [
+        field for field in active_contract.required_fields if field not in payload
+    ]
+    if missing:
+        raise ValueError(f"LLM response missing required fields: {sorted(missing)}")
+
+    decision = payload.get("decision")
+    if decision not in active_contract.allowed_decisions:
+        raise ValueError(
+            f"Invalid decision '{decision}'. Expected one of {active_contract.allowed_decisions}."
+        )
+
+    refined_workflow = payload.get("refined_workflow")
+    if not isinstance(refined_workflow, dict):
+        raise ValueError("refined_workflow must be a JSON object/dict")
+
+    return payload
+
+
+def generate_refinement(
+    workflow_data: Mapping[str, Any],
+    evaluation_report: Mapping[str, Any],
+    depth: int,
+    llm_generate: Callable[..., str],
+    contract: Optional[RefinementContract] = None,
+) -> Dict[str, Any]:
+    """Invoke the LLM with the refinement prompt and parse the result."""
+
+    active_contract = contract or RefinementContract()
+    prompt = build_refinement_prompt(workflow_data, evaluation_report, depth, contract)
+
+    # Consumers can pass a callable with any signature that accepts a prompt and
+    # returns a string. Keyword arguments are not mandated to keep the adapter
+    # flexible across providers.
+    raw_response = llm_generate(prompt)
+    parsed = parse_refinement_response(raw_response, active_contract)
+    parsed["contract_version"] = active_contract.version
+    return parsed
+
+
+# NOTE: ``generate_text`` remains the lightweight adapter entry point for
+# environments that expose a global LLM generator. It intentionally raises an
+# informative error by default to encourage explicit wiring via ``llm_generate``
+# when used in RecursionManager.
+def generate_text(prompt: str, **_: Any) -> str:  # pragma: no cover - passthrough
+    """Default generate_text placeholder.
+
+    Replace this with the actual LLM provider hook (e.g., OpenAI client) or
+    supply a custom ``llm_generate`` function to ``generate_refinement``.
+    """
+
+    raise RuntimeError(
+        "No LLM backend configured. Provide llm_generate to generate_refinement "
+        "or monkey-patch modules.llm_adapter.generate_text."
+    )

--- a/tests/test_llm_refinement_contract.py
+++ b/tests/test_llm_refinement_contract.py
@@ -1,0 +1,48 @@
+import json
+
+import pytest
+
+from generator.recursion_manager import RecursionManager
+from modules.llm_adapter import parse_refinement_response, RefinementContract
+
+
+def test_parse_refinement_response_enforces_contract():
+    contract = RefinementContract()
+    payload = {
+        "decision": "revise",
+        "refined_workflow": {"modules": ["a"]},
+        "reasoning": "Adds clarity",
+        "confidence": 0.72,
+        "score_delta": 1.3,
+    }
+
+    parsed = parse_refinement_response(json.dumps(payload), contract)
+    assert parsed == payload
+
+    payload["decision"] = "unknown"
+    with pytest.raises(ValueError):
+        parse_refinement_response(json.dumps(payload), contract)
+
+
+def test_recursion_manager_merges_llm_refinement_payload():
+    def fake_generate(prompt: str) -> str:  # pylint: disable=unused-argument
+        response = {
+            "decision": "accept",
+            "refined_workflow": {"summary": "refined", "modules": ["m1"]},
+            "reasoning": "Clearer steps",
+            "confidence": 0.9,
+            "score_delta": 2.1,
+        }
+        return json.dumps(response)
+
+    workflow = {"workflow_id": "wf-1", "modules": ["m0"]}
+    evaluation = {"clarity": 0.5}
+
+    manager = RecursionManager(llm_generate=fake_generate)
+    refined = manager.refine_workflow(workflow, evaluation, depth=1)
+
+    assert refined["modules"] == ["m1"]
+    metadata = refined.get("recursion_metadata", {})
+    assert metadata["llm_decision"] == "accept"
+    assert metadata["llm_contract_version"] == manager.contract.version
+    assert metadata["llm_status"] == "ok"


### PR DESCRIPTION
## Summary
- define a strict LLM refinement contract plus prompt/render helpers in `modules.llm_adapter`
- wire `RecursionManager` to use the contract with a configurable LLM generator and metadata capture
- add tests covering contract validation and LLM-driven recursion merges

## Testing
- python -m pytest tests/test_llm_refinement_contract.py


