### PR TITLE
Harden recursion schema for predictable recursive expansion

### DIFF
--- a/schemas/recursion_schema.json
+++ b/schemas/recursion_schema.json
@@ -1,42 +1,157 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Tommy-Raven/SSWG-mvm1.0/tree/main/schemas/recursion_schema.json",
   "title": "Recursion Schema",
+  "description": "Domain-agnostic recursion controls that remain deterministic and inheritance-safe under recursive expansion.",
   "type": "object",
-  "required": [],
+  "required": ["depth_limit", "trigger_condition"],
+  "additionalProperties": false,
   "properties": {
+    "schema_version": {
+      "type": "string",
+      "description": "Version of the recursion schema contract used by the runtime.",
+      "pattern": "^\\d+\\.\\d+\\.\\d+(?:[a-zA-Z0-9._-]+)?$"
+    },
     "depth_limit": {
-      "type": "integer",
-      "minimum": 0
+      "$ref": "#/$defs/boundedInteger",
+      "description": "Maximum recursion depth that may be traversed."
+    },
+    "max_iterations": {
+      "$ref": "#/$defs/boundedInteger",
+      "description": "Optional hard stop for total recursive iterations across all branches."
     },
     "trigger_condition": {
-      "type": "string"
-    },
-
-    "max_iterations": {
-      "type": "integer",
-      "minimum": 0
-    },
-    "auto_refine": {
-      "type": "boolean"
-    },
-    "require_human_approval": {
-      "type": "boolean"
-    },
-
-    "allow_recursive_refinement": {
-      "type": "boolean"
-    },
-    "preferred_modes": {
-      "type": "array",
-      "items": { "type": "string" }
+      "$ref": "#/$defs/nonEmptyString",
+      "description": "Primary condition that authorizes recursion entry."
     },
     "trigger_conditions": {
       "type": "array",
-      "items": { "type": "string" }
+      "description": "Supplemental conditions that all must be satisfied for recursion to proceed.",
+      "items": { "$ref": "#/$defs/nonEmptyString" },
+      "minItems": 1,
+      "uniqueItems": true
+    },
+    "regeneration_threshold": {
+      "type": "number",
+      "description": "Normalized threshold (0-1) that gates whether regeneration occurs.",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "feedback_source": {
+      "$ref": "#/$defs/nonEmptyString",
+      "description": "Source identifier for the feedback stream that drives recursion decisions."
+    },
+    "auto_refine": {
+      "type": "boolean",
+      "description": "Whether recursion may self-initiate refinement without human gating.",
+      "default": false
+    },
+    "require_human_approval": {
+      "type": "boolean",
+      "description": "If true, recursion branches must be acknowledged by a human before execution.",
+      "default": false
+    },
+    "allow_recursive_refinement": {
+      "type": "boolean",
+      "description": "Whether recursive re-entry is permitted after a refinement cycle.",
+      "default": true
+    },
+    "preferred_modes": {
+      "type": "array",
+      "description": "Preferred recursion execution modes (engine-defined but namespaced).",
+      "items": { "$ref": "#/$defs/mode" },
+      "uniqueItems": true
+    },
+    "policies": {
+      "type": "array",
+      "description": "Explicit policy list applied to every recursion hop; namespaced to avoid collisions.",
+      "items": { "$ref": "#/$defs/policy" },
+      "uniqueItems": true
+    },
+    "expansion_tree": {
+      "$ref": "#/$defs/recursion_node",
+      "description": "Recursive plan describing branch-specific constraints in a predictable tree structure."
+    },
+    "evaluation_schema": {
+      "$ref": "evaluation_schema.json",
+      "description": "Evaluation contract used to assess recursion outputs."
+    },
+    "history_log": {
+      "type": "array",
+      "description": "Ordered log identifiers for prior recursion invocations.",
+      "items": { "$ref": "#/$defs/nonEmptyString" }
     },
     "metadata": {
-      "$ref": "recursion_schema.json"
+      "$ref": "metadata_schema.json",
+      "description": "Optional descriptive metadata for the recursion contract."
+    },
+    "extensions": {
+      "type": "object",
+      "description": "Namespaced domain-specific extensions; keys must be collision-safe.",
+      "patternProperties": {
+        "^[a-zA-Z][\\w.-]*$": {
+          "description": "Any JSON-compatible payload scoped under a stable namespace key.",
+          "type": ["string", "number", "integer", "boolean", "array", "object", "null"]
+        }
+      },
+      "additionalProperties": false
     }
   },
-  "additionalProperties": false
+  "$defs": {
+    "boundedInteger": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "mode": {
+      "type": "string",
+      "description": "Adapter-defined recursion mode identifier (e.g., depth-first, breadth-first).",
+      "pattern": "^[a-zA-Z][\\w-]*$",
+      "minLength": 1
+    },
+    "policy": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "$ref": "#/$defs/nonEmptyString" },
+        "description": { "type": "string" },
+        "constraints": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        },
+        "inherit_from": {
+          "type": "array",
+          "description": "Policies this policy derives from (resolved by name); prevents ambiguous inheritance.",
+          "items": { "$ref": "#/$defs/nonEmptyString" },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    },
+    "recursion_node": {
+      "type": "object",
+      "required": ["id"],
+      "properties": {
+        "id": { "$ref": "#/$defs/nonEmptyString" },
+        "condition": { "$ref": "#/$defs/nonEmptyString" },
+        "limit": { "$ref": "#/$defs/boundedInteger" },
+        "strategy": { "$ref": "#/$defs/mode" },
+        "policies": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/policy" },
+          "uniqueItems": true
+        },
+        "children": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/recursion_node" },
+          "uniqueItems": true
+        }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/schemas/schemas.md
+++ b/schemas/schemas.md
@@ -282,14 +282,23 @@ Key Properties
 Type: object
 Required: depth_limit, trigger_condition
 
-• depth_limit – integer ≥ 1
-• trigger_condition – string
-• regeneration_threshold – number [0, 1]
-• feedback_source – string
+• schema_version – semantic version string for the contract in use
+• depth_limit – integer ≥ 1 (hard cap on recursion depth)
+• max_iterations – integer ≥ 1 (optional total branch limit)
+• trigger_condition – primary string condition that enables recursion
+• trigger_conditions – array of supplemental non-empty conditions (unique, minItems = 1)
+• regeneration_threshold – number [0, 1] gating regeneration
+• feedback_source – non-empty string identifying the feedback driver
+• auto_refine / require_human_approval / allow_recursive_refinement – booleans controlling authority and re-entry
+• preferred_modes – array of namespaced mode identifiers
+• policies – array of policy objects (name, optional description/constraints/inherit_from)
+• expansion_tree – recursive tree of branch nodes (id, optional condition/limit/strategy/policies/children)
 • evaluation_schema – $ref evaluation_schema.json
-• history_log – array of strings
+• history_log – array of non-empty strings
+• metadata – $ref metadata_schema.json
+• extensions – namespaced object for domain-specific payloads (keys must match ^[a-zA-Z][\w.-]*$)
 
-Strictness: additionalProperties = false
+Strictness: additionalProperties = false; extensions are the sole sanctioned expansion point.
 
 Referenced by: workflow_schema.json → recursion
 


### PR DESCRIPTION
## Summary
- strengthen recursion schema with a canonical id, strict constraints, and reusable definitions for predictable recursive expansion
- add namespaced policies, execution modes, and extension points to keep recursion configurations unambiguous and inheritance-safe
- update schema documentation to reflect the hardened recursion contract and allowable extensions

## Testing
- python -m json.tool schemas/recursion_schema.json
