### PR TITLE
Stabilize meta knowledge repository memory model

### DIFF
--- a/meta_knowledge_repo/__init__.py
+++ b/meta_knowledge_repo/__init__.py
@@ -1,1 +1,26 @@
 """Knowledge repository utilities for versioned metadata."""
+
+from meta_knowledge_repo.change_logs import ChangeLog, ChangeLogEntry
+from meta_knowledge_repo.evolutions import (
+    ConflictResolution,
+    MetaKnowledgeRepository,
+)
+from meta_knowledge_repo.versioning import (
+    DomainAnchor,
+    DomainRevision,
+    TRUST_TIERS,
+    deep_merge,
+    trust_rank,
+)
+
+__all__ = [
+    "ChangeLog",
+    "ChangeLogEntry",
+    "ConflictResolution",
+    "DomainAnchor",
+    "DomainRevision",
+    "MetaKnowledgeRepository",
+    "TRUST_TIERS",
+    "deep_merge",
+    "trust_rank",
+]

--- a/meta_knowledge_repo/change_logs.py
+++ b/meta_knowledge_repo/change_logs.py
@@ -1,1 +1,58 @@
-"""Change log utilities for the metadata knowledge repository."""
+"""Change log utilities for the metadata knowledge repository.
+
+Change logs answer the question: *what changed and why?* They provide a
+traceable narrative for revisions so that downstream artifacts can
+explain their lineage and reconcile disagreements deterministically.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, List, Optional
+
+
+@dataclass
+class ChangeLogEntry:
+    """A single recorded change in the repository."""
+
+    domain: str
+    revision_id: str
+    summary: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    conflicts: List[str] = field(default_factory=list)
+    supersedes: Optional[str] = None
+
+
+class ChangeLog:
+    """Append-only change log for meta knowledge revisions."""
+
+    def __init__(self) -> None:
+        self._entries: List[ChangeLogEntry] = []
+
+    def record(
+        self,
+        domain: str,
+        revision_id: str,
+        summary: str,
+        supersedes: Optional[str] = None,
+        conflicts: Optional[Iterable[str]] = None,
+    ) -> ChangeLogEntry:
+        """Add a new entry to the change log."""
+
+        entry = ChangeLogEntry(
+            domain=domain,
+            revision_id=revision_id,
+            summary=summary,
+            supersedes=supersedes,
+            conflicts=list(conflicts or []),
+        )
+        self._entries.append(entry)
+        return entry
+
+    def history(self, domain: Optional[str] = None) -> List[ChangeLogEntry]:
+        """Return the change history, optionally filtered by domain."""
+
+        if domain is None:
+            return list(self._entries)
+        return [entry for entry in self._entries if entry.domain == domain]

--- a/meta_knowledge_repo/evolutions.py
+++ b/meta_knowledge_repo/evolutions.py
@@ -1,1 +1,231 @@
-"""Evolution tracking for knowledge repository entries."""
+"""Evolution tracking for knowledge repository entries.
+
+This module captures the life cycle of domain knowledge:
+
+- Domains are anchored once to avoid competing "roots".
+- Revisions form explicit chains via ``parent_revision_id``.
+- Conflicts are resolved deterministically to avoid divergent truths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Optional
+
+from meta_knowledge_repo.change_logs import ChangeLog
+from meta_knowledge_repo.versioning import (
+    DomainAnchor,
+    DomainRevision,
+    deep_merge,
+    trust_rank,
+)
+
+
+@dataclass
+class ConflictResolution:
+    """Outcome of resolving two competing revisions."""
+
+    chosen: DomainRevision
+    superseded: DomainRevision
+    rationale: str
+
+
+class MetaKnowledgeRepository:
+    """In-memory registry for long-lived domain knowledge."""
+
+    def __init__(self) -> None:
+        self.anchors: Dict[str, DomainAnchor] = {}
+        self.revisions: Dict[str, Dict[str, DomainRevision]] = {}
+        self.heads: Dict[str, str] = {}
+        self.changelog = ChangeLog()
+
+    # ------------------------------------------------------------------ #
+    # Anchoring
+    # ------------------------------------------------------------------ #
+    def anchor_domain(
+        self, domain: str, root_revision: DomainRevision, created_by: str = "system"
+    ) -> DomainAnchor:
+        """Register the single source of truth for a domain."""
+
+        if domain in self.anchors:
+            raise ValueError(f"Domain '{domain}' is already anchored")
+        if root_revision.parent_revision_id is not None:
+            raise ValueError("Root revision must not declare a parent")
+
+        anchor = DomainAnchor(
+            domain=domain,
+            root_revision_id=root_revision.revision_id,
+            created_by=created_by,
+        )
+        self.anchors[domain] = anchor
+        self.revisions[domain] = {root_revision.revision_id: root_revision}
+        self.heads[domain] = root_revision.revision_id
+
+        self.changelog.record(
+            domain=domain,
+            revision_id=root_revision.revision_id,
+            summary="Anchored domain root revision.",
+        )
+        return anchor
+
+    # ------------------------------------------------------------------ #
+    # Revision management
+    # ------------------------------------------------------------------ #
+    def current(self, domain: str) -> Optional[DomainRevision]:
+        head_id = self.heads.get(domain)
+        if head_id is None:
+            return None
+        return self.revisions[domain][head_id]
+
+    def get_revision(self, domain: str, revision_id: str) -> DomainRevision:
+        try:
+            return self.revisions[domain][revision_id]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise ValueError(f"Unknown revision '{revision_id}' for domain '{domain}'") from exc
+
+    def add_revision(
+        self,
+        revision: DomainRevision,
+        conflicts: Optional[Iterable[str]] = None,
+        summary: str = "Added revision",
+    ) -> DomainRevision:
+        """Add a revision, resolving conflicts if the head has drifted."""
+
+        self._assert_domain_is_anchored(revision.domain)
+        domain_revisions = self.revisions[revision.domain]
+
+        if revision.parent_revision_id and revision.parent_revision_id not in domain_revisions:
+            raise ValueError(
+                f"Parent revision '{revision.parent_revision_id}' missing for domain '{revision.domain}'"
+            )
+
+        if revision.revision_id in domain_revisions:
+            raise ValueError(
+                f"Revision id '{revision.revision_id}' already exists for domain '{revision.domain}'"
+            )
+
+        current_revision = self.current(revision.domain)
+        supersedes_id = revision.parent_revision_id
+        if current_revision and revision.parent_revision_id != current_revision.revision_id:
+            resolution = self._resolve_conflict(current_revision, revision)
+            revision = resolution.chosen
+            supersedes_id = resolution.superseded.revision_id
+            conflicts = list(conflicts or []) + [resolution.rationale]
+            summary = f"Resolved conflict; superseded {resolution.superseded.revision_id}"
+
+        if revision.revision_id in domain_revisions:
+            # Conflict resolution kept the incumbent; record the clash but
+            # do not duplicate the stored revision.
+            self.heads[revision.domain] = revision.revision_id
+            self.changelog.record(
+                domain=revision.domain,
+                revision_id=revision.revision_id,
+                summary=summary,
+                supersedes=supersedes_id,
+                conflicts=conflicts,
+            )
+            return revision
+
+        domain_revisions[revision.revision_id] = revision
+        self.heads[revision.domain] = revision.revision_id
+        self.changelog.record(
+            domain=revision.domain,
+            revision_id=revision.revision_id,
+            summary=summary,
+            supersedes=supersedes_id,
+            conflicts=conflicts,
+        )
+        return revision
+
+    def inherit(
+        self,
+        domain: str,
+        revision_id: str,
+        payload_patch: Dict[str, object],
+        rationale: str,
+        trust_tier: Optional[str] = None,
+        sources: Optional[List[str]] = None,
+        conflicts: Optional[Iterable[str]] = None,
+    ) -> DomainRevision:
+        """Create and store a revision that explicitly inherits from head."""
+
+        parent = self.current(domain)
+        if parent is None:
+            raise ValueError(f"Domain '{domain}' is not anchored")
+
+        candidate = parent.derive(
+            revision_id=revision_id,
+            payload_patch=payload_patch,
+            rationale=rationale,
+            trust_tier=trust_tier,
+            sources=sources,
+            conflicts_resolved=list(conflicts or []),
+        )
+        return self.add_revision(candidate, conflicts=conflicts, summary=rationale)
+
+    # ------------------------------------------------------------------ #
+    # Conflict resolution
+    # ------------------------------------------------------------------ #
+    def _resolve_conflict(
+        self, existing: DomainRevision, incoming: DomainRevision
+    ) -> ConflictResolution:
+        """Resolve disagreement between the current head and an incoming revision."""
+
+        existing_rank = trust_rank(existing.trust_tier)
+        incoming_rank = trust_rank(incoming.trust_tier)
+
+        if incoming_rank > existing_rank:
+            rationale = self._format_rationale(
+                "Incoming revision has higher trust tier", existing, incoming
+            )
+            chosen = _merge_with_lineage(existing, incoming)
+            superseded = existing
+        elif incoming_rank < existing_rank:
+            rationale = self._format_rationale(
+                "Existing head has higher trust tier", existing, incoming
+            )
+            chosen = existing
+            superseded = incoming
+        else:
+            if incoming.created_at > existing.created_at:
+                rationale = self._format_rationale(
+                    "Tied trust tier; prefer freshest revision", existing, incoming
+                )
+                chosen = _merge_with_lineage(existing, incoming)
+                superseded = existing
+            else:
+                rationale = self._format_rationale(
+                    "Tied trust tier; retain incumbent", existing, incoming
+                )
+                chosen = existing
+                superseded = incoming
+
+        return ConflictResolution(chosen=chosen, superseded=superseded, rationale=rationale)
+
+    @staticmethod
+    def _format_rationale(reason: str, existing: DomainRevision, incoming: DomainRevision) -> str:
+        return (
+            f"{reason}: existing={existing.revision_id} ({existing.trust_tier}), "
+            f"incoming={incoming.revision_id} ({incoming.trust_tier})"
+        )
+
+    def _assert_domain_is_anchored(self, domain: str) -> None:
+        if domain not in self.anchors:
+            raise ValueError(f"Domain '{domain}' has not been anchored yet")
+
+
+def _merge_with_lineage(existing: DomainRevision, incoming: DomainRevision) -> DomainRevision:
+    """Merge payloads while preserving the incoming lineage."""
+
+    merged_payload = deep_merge(existing.payload, incoming.payload)
+    return DomainRevision(
+        domain=incoming.domain,
+        revision_id=incoming.revision_id,
+        parent_revision_id=incoming.parent_revision_id,
+        payload=merged_payload,
+        trust_tier=incoming.trust_tier,
+        rationale=incoming.rationale,
+        sources=list(incoming.sources),
+        conflicts_resolved=list(incoming.conflicts_resolved)
+        + [f"Merged with {existing.revision_id}"],
+    )

--- a/meta_knowledge_repo/meta_knowledge_repo.md
+++ b/meta_knowledge_repo/meta_knowledge_repo.md
@@ -1,1 +1,77 @@
- → change logs, evolutions, versioning
+# meta_knowledge_repo — long-term creative memory (MVM)
+
+The meta knowledge repository is the **single source of truth** for
+long-lived domain definitions (story worlds, tone guides, character
+ontologies, etc.). The memory model prioritizes traceability over size so
+that we can explain *why* a fact is present and how it evolved.
+
+## Memory model guarantees
+
+- **Single source of truth per domain:** Each domain is anchored once via
+  `DomainAnchor` and all future revisions point back to that root.
+- **Explicit inheritance:** Every non-root `DomainRevision` records its
+  `parent_revision_id`; derived revisions merge a *patch* onto the parent
+  payload rather than overwriting it wholesale.
+- **Deterministic conflict resolution:** When memories disagree, the
+  repository resolves the conflict by trust tier first, then recency, and
+  merges payloads to avoid dropping information.
+
+## Core types
+
+- `DomainAnchor` — declares the authoritative root revision id for a
+  domain. Prevents dueling roots.
+- `DomainRevision` — structured content plus lineage (parent id,
+  trust tier, rationale, sources, and conflicts resolved).
+- `ChangeLogEntry` — append-only audit trail describing why a revision
+  was recorded and what it superseded.
+
+## Repository behaviors
+
+### Anchoring
+
+```python
+repo.anchor_domain(
+    domain="story_worlds",
+    root_revision=DomainRevision(
+        domain="story_worlds",
+        revision_id="v1",
+        payload={"canon": {"cities": ["Anodyne"]}},
+        trust_tier="authoritative",
+        rationale="Initial world bible",
+    ),
+    created_by="lore-team",
+)
+```
+
+- Enforces a single anchor per domain.
+- Rejects root revisions that already declare a parent.
+
+### Inheritance and evolution
+
+```python
+repo.inherit(
+    domain="story_worlds",
+    revision_id="v2",
+    payload_patch={"canon": {"cities": ["Anodyne", "Verdance"]}},
+    rationale="Added new capital city after expedition",
+    trust_tier="validated",
+)
+```
+
+- Uses `deep_merge` to layer the patch on top of the parent payload.
+- Captures rationale and optional sources/flags used to generate the
+  update.
+- Emits a change log entry noting which revision was superseded.
+
+### Conflict resolution rules
+
+Conflicts are raised when an incoming revision targets an outdated
+parent. The repository resolves them deterministically:
+
+1. Higher `trust_tier` wins (`authoritative` > `validated` > `observed`).
+2. If trust ties, prefer the freshest `created_at`.
+3. Merge payloads to prevent data loss while appending a conflict note to
+   `conflicts_resolved`.
+
+The resulting revision becomes the new head; the superseded revision is
+still retained for lineage queries.

--- a/meta_knowledge_repo/versioning.py
+++ b/meta_knowledge_repo/versioning.py
@@ -1,3 +1,117 @@
-"""Versioning helpers for knowledge repository assets."""
+"""Versioning helpers for knowledge repository assets.
 
-# meta memory placeholder file
+The meta knowledge repository is responsible for **long-lived creative
+memories**. This module defines the canonical revision model for each
+domain along with helpers for deriving new revisions from existing ones.
+
+Goals:
+- Single source of truth per domain (anchored via ``DomainAnchor``).
+- Explicit inheritance between revisions (``parent_revision_id`` is
+  required for any non-root revision).
+- Predictable conflict resolution rules for cases where two revisions
+  disagree.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+TRUST_TIERS = ["observed", "validated", "authoritative"]
+TRUST_WEIGHT = {value: index for index, value in enumerate(TRUST_TIERS)}
+
+
+@dataclass(frozen=True)
+class DomainAnchor:
+    """Single source of truth for a domain.
+
+    Each domain has exactly one anchor which records the root revision.
+    The anchor prevents competing "roots" from emerging and makes it
+    clear which revision other artifacts should inherit from.
+    """
+
+    domain: str
+    root_revision_id: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    created_by: str = "system"
+
+
+@dataclass
+class DomainRevision:
+    """A single revision of a domain definition.
+
+    Attributes:
+        domain: Domain identifier (e.g., "story_structure").
+        revision_id: Unique identifier for this revision.
+        parent_revision_id: The revision this one inherits from. ``None``
+            for the root revision only.
+        payload: Arbitrary structured content describing the domain.
+        trust_tier: Qualitative trust level (``observed`` < ``validated``
+            < ``authoritative``).
+        rationale: Short note on why this revision was produced.
+        sources: Optional upstream references used to build this revision.
+        conflicts_resolved: Human-readable descriptions of conflicts
+            handled while producing this revision.
+        created_at: Timestamp for tie-breaking during conflict resolution.
+    """
+
+    domain: str
+    revision_id: str
+    payload: Dict[str, Any]
+    parent_revision_id: Optional[str] = None
+    trust_tier: str = "observed"
+    rationale: str = ""
+    sources: List[str] = field(default_factory=list)
+    conflicts_resolved: List[str] = field(default_factory=list)
+    created_at: datetime = field(default_factory=datetime.utcnow)
+
+    def derive(
+        self,
+        revision_id: str,
+        payload_patch: Dict[str, Any],
+        rationale: str,
+        trust_tier: Optional[str] = None,
+        sources: Optional[List[str]] = None,
+        conflicts_resolved: Optional[List[str]] = None,
+    ) -> "DomainRevision":
+        """Create a child revision with explicit inheritance.
+
+        The new revision merges ``payload_patch`` on top of the current
+        payload, preserving the inheritance chain via
+        ``parent_revision_id``.
+        """
+
+        merged_payload = deep_merge(self.payload, payload_patch)
+        return DomainRevision(
+            domain=self.domain,
+            revision_id=revision_id,
+            parent_revision_id=self.revision_id,
+            payload=merged_payload,
+            trust_tier=trust_tier or self.trust_tier,
+            rationale=rationale,
+            sources=list(sources or self.sources),
+            conflicts_resolved=list(conflicts_resolved or []),
+        )
+
+
+def deep_merge(base: Dict[str, Any], patch: Dict[str, Any]) -> Dict[str, Any]:
+    """Recursively merge ``patch`` into ``base`` without mutating inputs."""
+
+    merged: Dict[str, Any] = {**base}
+    for key, value in patch.items():
+        if (
+            key in merged
+            and isinstance(merged[key], dict)
+            and isinstance(value, dict)
+        ):
+            merged[key] = deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
+def trust_rank(trust_tier: str) -> int:
+    """Return the ordinal rank for a trust tier (lower is weaker)."""
+
+    return TRUST_WEIGHT.get(trust_tier, -1)


### PR DESCRIPTION
## Summary
- introduce anchor and revision data models to enforce single-source lineage in the meta knowledge repository
- add conflict resolution and change-log handling that favor higher trust tiers and explicit inheritance
- document the memory model guarantees and usage patterns for long-lived creative domains

## Testing
- python -m compileall meta_knowledge_repo
