### PR TITLE
Add machine-enforceable root contracts, JSON schemas, and CI validation

### DIFF
--- a/.github/workflows/sswg-mvm-ci.yml
+++ b/.github/workflows/sswg-mvm-ci.yml
@@ -3,6 +3,13 @@ name: SSWG MVM CI & Validation
 on:
   push:
     paths:
+      - "sswg.yaml"
+      - "mvm.yaml"
+      - "execution_policy.yaml"
+      - "governance.yaml"
+      - "invariants.yaml"
+      - "root_contract.yaml"
+      - "ai_system_prompt.txt"
       - "data/templates/**"
       - "ai_validation/**"
       - "schemas/**"
@@ -13,6 +20,13 @@ on:
       - ".github/workflows/sswg-mvm-ci.yml"
   pull_request:
     paths:
+      - "sswg.yaml"
+      - "mvm.yaml"
+      - "execution_policy.yaml"
+      - "governance.yaml"
+      - "invariants.yaml"
+      - "root_contract.yaml"
+      - "ai_system_prompt.txt"
       - "data/templates/**"
       - "ai_validation/**"
       - "schemas/**"
@@ -51,6 +65,11 @@ jobs:
       - name: Schema validation (example workflows)
         run: |
           python -c "from ai_validation.schema_validator import validate_workflow; import json; import sys; wf=json.load(open('data/templates/campfire_workflow.json')); ok, errs=validate_workflow(wf); sys.exit(1 if not ok else 0)"
+
+      - name: Root contract validation
+        run: |
+          python scripts/validate_root_contracts.py
+          python scripts/lint_casing.py
 
       - name: Run tests
         run: |

--- a/ai_system_prompt.txt
+++ b/ai_system_prompt.txt
@@ -1,0 +1,21 @@
+You are bound to the repository root contracts.
+
+authoritative files (must be loaded and enforced before any action):
+- sswg.yaml
+- mvm.yaml
+- execution_policy.yaml
+- governance.yaml
+- invariants.yaml
+- root_contract.yaml
+
+binding rules:
+- treat sswg and mvm as software/system identifiers only.
+- obey execution_model phases, artifact_policy constraints, determinism requirements, validation mandates, and authority precedence from sswg.
+- enforce mvm requirements, exclusions, extension_model constraints, and enforcement behavior.
+- follow execution_policy measurement, interpretation, randomness, and tooling rules.
+- apply governance change_control and validation_gates for repository operations.
+- enforce invariants without exceptions.
+
+output constraints:
+- validate any generated configs, repos, workflows, schemas, and tooling outputs against the listed contracts.
+- fail closed on violations.

--- a/execution_policy.yaml
+++ b/execution_policy.yaml
@@ -1,0 +1,28 @@
+execution_policy:
+  measurement:
+    rules:
+      - measurement_steps_must_be_deterministic
+      - measurement_outputs_must_be_reproducible
+      - measurement_keys_must_be_bijective
+
+  interpretation:
+    allowed_only_if:
+      - measurement_completed
+      - interpretation_outputs_labeled_non_deterministic
+    forbidden_if:
+      - replacing_missing_data
+      - influencing_measurement_steps
+
+  randomness:
+    allowed_when:
+      - explicitly_logged
+      - used_as_sampling_input
+    forbidden_when:
+      - used_in_identifiers
+      - used_in_measurement_outputs
+
+  tooling:
+    selection_rules:
+      - tool_must_meet_output_guarantees
+      - convenience_does_not_override_correctness
+    mismatch_policy: invalidate_tool

--- a/governance.yaml
+++ b/governance.yaml
@@ -1,0 +1,28 @@
+governance:
+  repository_role: canonical_sswg_repo
+
+  directories:
+    immutable:
+      - generator/
+      - cli/
+      - pdl/
+      - reproducibility/
+    additive_only:
+      - artifacts/
+      - data/
+      - docs/
+
+  change_control:
+    required:
+      - branch_or_fork
+      - validation_pass
+      - review
+    forbidden:
+      - direct_main_mutation
+      - artifact_rewrites
+
+  validation_gates:
+    pre_merge:
+      - schema_validation
+      - phase_validation
+      - reproducibility_validation

--- a/invariants.yaml
+++ b/invariants.yaml
@@ -1,0 +1,17 @@
+invariants:
+  - id: deterministic_measurement
+    rule: >
+      Any output used for measurement, indexing, or comparison must be
+      produced by a deterministic process.
+
+  - id: bijective_identifiers
+    rule: >
+      Identifiers used for labeling must be unique, gap-free, and reproducible.
+
+  - id: artifacts_not_canonical
+    rule: >
+      Generated artifacts must not redefine or overwrite canonical structures.
+
+  - id: validation_required
+    rule: >
+      Outputs that fail validation must not be promoted or reused.

--- a/mvm.yaml
+++ b/mvm.yaml
@@ -1,46 +1,35 @@
 mvm:
   system_name: mvm
-  version: v0.0.9mvm
   description: >
-    mvm defines the minimum acceptable completeness for sswg software.
-    workflows and tooling are invalid unless the 9-phase pipeline is supported.
+    mvm defines the minimum acceptable completeness for software produced
+    under sswg. Code or workflows below this threshold are invalid.
 
-  required_pipeline:
-    canonical_set: full_9_phase
-    phases_must_exist:
-      - ingest
-      - normalize
-      - parse
-      - analyze
-      - generate
-      - validate
-      - compare
-      - interpret
-      - log
-
-  minimum_artifacts:
+  requirements:
     must_include:
-      - schemas/
-      - pdl/
-      - validation_entrypoints
+      - schemas
+      - phase_definitions
+      - validation_paths
       - logging_outputs
-    must_validate:
-      - pdl_phase_set_schema
-      - phase_level_schemas
+    must_exhibit:
+      - deterministic_behavior
+      - reproducibility_from_clean_env
+      - explicit_configuration
 
-  minimum_behaviors:
-    deterministic:
-      required_for_phases: [normalize, analyze, validate, compare]
-    audit_ready_outputs:
-      must_support:
-        - bijective_identifiers
-        - replayable_runs
-        - delta_comparisons
+  exclusions:
+    not_equivalent_to:
+      - mvp
+      - prototype
+      - proof_of_concept
+
+  extension_model:
+    allowed:
+      - additive_modules
+      - stricter_validation
+      - new_phases_with_pdl
+    forbidden:
+      - weakening_constraints
+      - bypassing_validation
+      - redefining_existing_fields
 
   enforcement:
     failure_behavior: stop_execution
-    required_failure_label:
-      Type: deterministic_failure
-    rule: >
-      if any deterministic requirement is violated, execution must halt and
-      the failing phase must emit Type: deterministic_failure.

--- a/root_contract.yaml
+++ b/root_contract.yaml
@@ -1,0 +1,168 @@
+root_contract:
+  sswg:
+    system_name: sswg
+    description: >
+      sswg is a phase-driven workflow generation and validation system.
+      This file defines mandatory execution rules, constraints, and
+      interoperability requirements for all tooling operating in this repository.
+
+    execution_model:
+      phases:
+        ordered: true
+        canonical:
+          - ingest
+          - parse
+          - generate
+          - output
+          - validate
+          - log
+      rules:
+        - phases_must_be_explicit
+        - phases_must_define_inputs_and_outputs
+        - phases_must_be_independently_executable
+
+    artifact_policy:
+      canonical_layers:
+        - generator/
+        - cli/
+        - pdl/
+        - reproducibility/
+      generated_layers:
+        - artifacts/
+        - data/
+        - docs/
+      rules:
+        - generated_layers_are_additive_only
+        - canonical_layers_must_not_be_mutated_by_generators
+
+    determinism:
+      required_for:
+        - measurement
+        - labeling
+        - indexing
+        - comparison
+      forbidden_tools_for_determinism:
+        - generative_image_models
+        - stochastic_labeling
+
+    validation:
+      mandatory:
+        - schema_validation
+        - phase_integrity_validation
+        - reproducibility_check
+
+    authority:
+      precedence: highest
+      violation_policy: hard_fail
+
+  mvm:
+    system_name: mvm
+    description: >
+      mvm defines the minimum acceptable completeness for software produced
+      under sswg. Code or workflows below this threshold are invalid.
+
+    requirements:
+      must_include:
+        - schemas
+        - phase_definitions
+        - validation_paths
+        - logging_outputs
+      must_exhibit:
+        - deterministic_behavior
+        - reproducibility_from_clean_env
+        - explicit_configuration
+
+    exclusions:
+      not_equivalent_to:
+        - mvp
+        - prototype
+        - proof_of_concept
+
+    extension_model:
+      allowed:
+        - additive_modules
+        - stricter_validation
+        - new_phases_with_pdl
+      forbidden:
+        - weakening_constraints
+        - bypassing_validation
+        - redefining_existing_fields
+
+    enforcement:
+      failure_behavior: stop_execution
+
+  execution_policy:
+    measurement:
+      rules:
+        - measurement_steps_must_be_deterministic
+        - measurement_outputs_must_be_reproducible
+        - measurement_keys_must_be_bijective
+
+    interpretation:
+      allowed_only_if:
+        - measurement_completed
+        - interpretation_outputs_labeled_non_deterministic
+      forbidden_if:
+        - replacing_missing_data
+        - influencing_measurement_steps
+
+    randomness:
+      allowed_when:
+        - explicitly_logged
+        - used_as_sampling_input
+      forbidden_when:
+        - used_in_identifiers
+        - used_in_measurement_outputs
+
+    tooling:
+      selection_rules:
+        - tool_must_meet_output_guarantees
+        - convenience_does_not_override_correctness
+      mismatch_policy: invalidate_tool
+
+  governance:
+    repository_role: canonical_sswg_repo
+
+    directories:
+      immutable:
+        - generator/
+        - cli/
+        - pdl/
+        - reproducibility/
+      additive_only:
+        - artifacts/
+        - data/
+        - docs/
+
+    change_control:
+      required:
+        - branch_or_fork
+        - validation_pass
+        - review
+      forbidden:
+        - direct_main_mutation
+        - artifact_rewrites
+
+    validation_gates:
+      pre_merge:
+        - schema_validation
+        - phase_validation
+        - reproducibility_validation
+
+  invariants:
+    - id: deterministic_measurement
+      rule: >
+        Any output used for measurement, indexing, or comparison must be
+        produced by a deterministic process.
+
+    - id: bijective_identifiers
+      rule: >
+        Identifiers used for labeling must be unique, gap-free, and reproducible.
+
+    - id: artifacts_not_canonical
+      rule: >
+        Generated artifacts must not redefine or overwrite canonical structures.
+
+    - id: validation_required
+      rule: >
+        Outputs that fail validation must not be promoted or reused.

--- a/schemas/execution_policy_schema.json
+++ b/schemas/execution_policy_schema.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Tommy-Raven/SSWG-mvm1.0/tree/main/schemas/execution_policy_schema.json",
+  "title": "execution policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["execution_policy"],
+  "properties": {
+    "execution_policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["measurement", "interpretation", "randomness", "tooling"],
+      "properties": {
+        "measurement": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["rules"],
+          "properties": {
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "interpretation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["allowed_only_if", "forbidden_if"],
+          "properties": {
+            "allowed_only_if": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "forbidden_if": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "randomness": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["allowed_when", "forbidden_when"],
+          "properties": {
+            "allowed_when": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "forbidden_when": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "tooling": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["selection_rules", "mismatch_policy"],
+          "properties": {
+            "selection_rules": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "mismatch_policy": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/governance_schema.json
+++ b/schemas/governance_schema.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Tommy-Raven/SSWG-mvm1.0/tree/main/schemas/governance_schema.json",
+  "title": "governance",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["governance"],
+  "properties": {
+    "governance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["repository_role", "directories", "change_control", "validation_gates"],
+      "properties": {
+        "repository_role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "directories": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["immutable", "additive_only"],
+          "properties": {
+            "immutable": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "additive_only": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "change_control": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required", "forbidden"],
+          "properties": {
+            "required": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "forbidden": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "validation_gates": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["pre_merge"],
+          "properties": {
+            "pre_merge": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/invariants_schema.json
+++ b/schemas/invariants_schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Tommy-Raven/SSWG-mvm1.0/tree/main/schemas/invariants_schema.json",
+  "title": "invariants",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["invariants"],
+  "properties": {
+    "invariants": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "rule"],
+        "properties": {
+          "id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "rule": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/mvm_contract_schema.json
+++ b/schemas/mvm_contract_schema.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Tommy-Raven/SSWG-mvm1.0/tree/main/schemas/mvm_contract_schema.json",
+  "title": "mvm minimum viable software definition",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["mvm"],
+  "properties": {
+    "mvm": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "system_name",
+        "description",
+        "requirements",
+        "exclusions",
+        "extension_model",
+        "enforcement"
+      ],
+      "properties": {
+        "system_name": {
+          "type": "string",
+          "const": "mvm"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "requirements": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["must_include", "must_exhibit"],
+          "properties": {
+            "must_include": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "must_exhibit": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "exclusions": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["not_equivalent_to"],
+          "properties": {
+            "not_equivalent_to": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "extension_model": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["allowed", "forbidden"],
+          "properties": {
+            "allowed": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "forbidden": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "enforcement": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["failure_behavior"],
+          "properties": {
+            "failure_behavior": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/root_contract_schema.json
+++ b/schemas/root_contract_schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Tommy-Raven/SSWG-mvm1.0/tree/main/schemas/root_contract_schema.json",
+  "title": "root contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["root_contract"],
+  "properties": {
+    "root_contract": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["sswg", "mvm", "execution_policy", "governance", "invariants"],
+      "properties": {
+        "sswg": {
+          "$ref": "sswg_contract_schema.json#/properties/sswg"
+        },
+        "mvm": {
+          "$ref": "mvm_contract_schema.json#/properties/mvm"
+        },
+        "execution_policy": {
+          "$ref": "execution_policy_schema.json#/properties/execution_policy"
+        },
+        "governance": {
+          "$ref": "governance_schema.json#/properties/governance"
+        },
+        "invariants": {
+          "$ref": "invariants_schema.json#/properties/invariants"
+        }
+      }
+    }
+  }
+}

--- a/schemas/sswg_contract_schema.json
+++ b/schemas/sswg_contract_schema.json
@@ -1,0 +1,150 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Tommy-Raven/SSWG-mvm1.0/tree/main/schemas/sswg_contract_schema.json",
+  "title": "sswg software system contract",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["sswg"],
+  "properties": {
+    "sswg": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "system_name",
+        "description",
+        "execution_model",
+        "artifact_policy",
+        "determinism",
+        "validation",
+        "authority"
+      ],
+      "properties": {
+        "system_name": {
+          "type": "string",
+          "const": "sswg"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "execution_model": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["phases", "rules"],
+          "properties": {
+            "phases": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["ordered", "canonical"],
+              "properties": {
+                "ordered": {
+                  "type": "boolean"
+                },
+                "canonical": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "minItems": 1
+                }
+              }
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "artifact_policy": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["canonical_layers", "generated_layers", "rules"],
+          "properties": {
+            "canonical_layers": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "generated_layers": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "rules": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "determinism": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["required_for", "forbidden_tools_for_determinism"],
+          "properties": {
+            "required_for": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            },
+            "forbidden_tools_for_determinism": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "validation": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["mandatory"],
+          "properties": {
+            "mandatory": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minItems": 1
+            }
+          }
+        },
+        "authority": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["precedence", "violation_policy"],
+          "properties": {
+            "precedence": {
+              "type": "string",
+              "minLength": 1
+            },
+            "violation_policy": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/lint_casing.py
+++ b/scripts/lint_casing.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Enforce lowercase casing rules for sswg/mvm contract files."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+TARGETS = [
+    "sswg.yaml",
+    "mvm.yaml",
+    "execution_policy.yaml",
+    "governance.yaml",
+    "invariants.yaml",
+    "root_contract.yaml",
+    "ai_system_prompt.txt",
+]
+
+DISALLOWED_UPPER = [re.compile(r"\bSSWG\b"), re.compile(r"\bMVM\b")]
+LOWERCASE_TERMS = ["configs", "repos", "workflows", "schemas", "tooling"]
+
+
+def lint_file(path: Path) -> list[str]:
+    violations: list[str] = []
+    lines = path.read_text(encoding="utf-8").splitlines()
+
+    for line_number, line in enumerate(lines, start=1):
+        for pattern in DISALLOWED_UPPER:
+            if pattern.search(line):
+                violations.append(
+                    f"{path.name}:{line_number}: disallowed uppercase term '{pattern.pattern}'"
+                )
+
+        for term in LOWERCASE_TERMS:
+            for match in re.finditer(rf"\b{term}\b", line, flags=re.IGNORECASE):
+                if match.group(0) != term:
+                    violations.append(
+                        f"{path.name}:{line_number}: '{match.group(0)}' must be lowercase '{term}'"
+                    )
+
+    return violations
+
+
+def main() -> int:
+    failures: list[str] = []
+
+    for target in TARGETS:
+        path = ROOT_DIR / target
+        if not path.exists():
+            failures.append(f"missing file: {target}")
+            continue
+        failures.extend(lint_file(path))
+
+    if failures:
+        print("casing lint failures:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("casing lint passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/local_ci.py
+++ b/scripts/local_ci.py
@@ -123,6 +123,22 @@ def task_template_regression_tests() -> TaskResult:
     )
 
 
+def task_root_contract_validation() -> TaskResult:
+    """Validate root contracts and casing rules."""
+    return run_command(
+        "root contract validation",
+        [sys.executable, "scripts/validate_root_contracts.py"],
+    )
+
+
+def task_root_casing_lint() -> TaskResult:
+    """Lint casing rules for root contracts."""
+    return run_command(
+        "root contract casing lint",
+        [sys.executable, "scripts/lint_casing.py"],
+    )
+
+
 def task_recursive_benchmark() -> TaskResult:
     """
     Run recursive benchmark / memory tracker.
@@ -146,6 +162,8 @@ def run_sswg_ci_suite() -> List[TaskResult]:
     """Run SSWG CI-style checks: lint + validation regressions."""
     results: List[TaskResult] = []
     results.append(task_lint_sswg())
+    results.append(task_root_contract_validation())
+    results.append(task_root_casing_lint())
     results.append(task_regression_tests())
     results.append(task_template_regression_tests())
     return results

--- a/scripts/validate_root_contracts.py
+++ b/scripts/validate_root_contracts.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Validate root contract yaml files against json schemas."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+from jsonschema import Draft202012Validator, RefResolver
+
+
+SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+CONTRACTS = {
+    "sswg.yaml": "sswg_contract_schema.json",
+    "mvm.yaml": "mvm_contract_schema.json",
+    "execution_policy.yaml": "execution_policy_schema.json",
+    "governance.yaml": "governance_schema.json",
+    "invariants.yaml": "invariants_schema.json",
+    "root_contract.yaml": "root_contract_schema.json",
+}
+
+
+def load_schema(schema_name: str) -> dict:
+    schema_path = SCHEMAS_DIR / schema_name
+    return yaml.safe_load(schema_path.read_text(encoding="utf-8"))
+
+
+def load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def get_validator(schema_name: str) -> Draft202012Validator:
+    schema = load_schema(schema_name)
+    base_uri = SCHEMAS_DIR.as_uri().rstrip("/") + "/"
+    resolver = RefResolver(base_uri=base_uri, referrer=schema)
+    return Draft202012Validator(schema, resolver=resolver)
+
+
+def validate_contracts() -> int:
+    failures: list[str] = []
+
+    for yaml_name, schema_name in CONTRACTS.items():
+        yaml_path = ROOT_DIR / yaml_name
+        if not yaml_path.exists():
+            failures.append(f"missing file: {yaml_name}")
+            continue
+
+        validator = get_validator(schema_name)
+        data = load_yaml(yaml_path)
+        errors = sorted(validator.iter_errors(data), key=lambda e: e.path)
+        if errors:
+            for error in errors:
+                path = "/".join(str(part) for part in error.path)
+                failures.append(f"{yaml_name}: {path or '<root>'}: {error.message}")
+
+    if failures:
+        print("root contract validation failures:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("root contract validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(validate_contracts())

--- a/sswg.yaml
+++ b/sswg.yaml
@@ -1,76 +1,54 @@
 sswg:
   system_name: sswg
-  version: v0.0.9mvm
   description: >
     sswg is a phase-driven workflow generation and validation system.
-    this repo enforces the full 9-phase pipeline for auditability and
-    deterministic measurement outputs.
+    This file defines mandatory execution rules, constraints, and
+    interoperability requirements for all tooling operating in this repository.
 
-  pipeline:
-    canonical_set: full_9_phase
+  execution_model:
     phases:
       ordered: true
-      required:
+      canonical:
         - ingest
-        - normalize
         - parse
-        - analyze
         - generate
+        - output
         - validate
-        - compare
-        - interpret
         - log
-
-  phase_separation:
-    enforced: true
-    rule: >
-      each phase must be declared explicitly and validated against its
-      phase-specific schema; phase behaviors must not be collapsed.
-
-  determinism:
-    required_for:
-      - normalize
-      - analyze
-      - validate
-      - compare
-    measurement_keys:
-      bijective_required: true
-      disallow_generative_tooling: true
-
-  failure_labeling:
-    required: true
-    label_schema:
-      required_fields: [Type, message, phase_id]
-      allowed_types:
-        - deterministic_failure
-        - schema_failure
-        - io_failure
-        - tool_mismatch
-        - reproducibility_failure
-    rule: >
-      when any phase fails a required invariant, the phase must emit a
-      failure label with Type: deterministic_failure (or other matching type)
-      and hard-fail execution.
+    rules:
+      - phases_must_be_explicit
+      - phases_must_define_inputs_and_outputs
+      - phases_must_be_independently_executable
 
   artifact_policy:
     canonical_layers:
-      immutable:
-        - generator/
-        - cli/
-        - pdl/
-        - reproducibility/
+      - generator/
+      - cli/
+      - pdl/
+      - reproducibility/
     generated_layers:
-      additive_only:
-        - artifacts/
-        - data/
-        - docs/
+      - artifacts/
+      - data/
+      - docs/
+    rules:
+      - generated_layers_are_additive_only
+      - canonical_layers_must_not_be_mutated_by_generators
 
-  validation_gates:
-    required:
+  determinism:
+    required_for:
+      - measurement
+      - labeling
+      - indexing
+      - comparison
+    forbidden_tools_for_determinism:
+      - generative_image_models
+      - stochastic_labeling
+
+  validation:
+    mandatory:
       - schema_validation
-      - phase_schema_validation
-      - invariants_validation
-      - reproducibility_validation
+      - phase_integrity_validation
+      - reproducibility_check
 
   authority:
     precedence: highest


### PR DESCRIPTION
### Motivation
- Replace human/interpretive root docs with machine-enforceable contracts that define required execution behavior and guarantees.
- Ensure `sswg` / `mvm` are treated as software/system identifiers and enforce lowercase usage for repository artifacts like `configs`, `repos`, `workflows`, `schemas`, and `tooling`.
- Provide a single root namespace for contract validation so tools can programmatically load and enforce repository-wide rules.

### Description
- Added consolidated `root_contract.yaml` and new contract files: `execution_policy.yaml`, `governance.yaml`, and `invariants.yaml`, and updated `sswg.yaml`/`mvm.yaml` to the machine-enforceable format using lowercase `sswg`/`mvm` identifiers.
- Implemented JSON Schemas under `schemas/` for each contract (`sswg_contract_schema.json`, `mvm_contract_schema.json`, `execution_policy_schema.json`, `governance_schema.json`, `invariants_schema.json`, `root_contract_schema.json`) to enable programmatic validation.
- Added validation and linting helpers: `scripts/validate_root_contracts.py` to validate the YAMLs against the JSON Schemas and `scripts/lint_casing.py` to enforce lowercase casing rules and disallow uppercase `SSWG`/`MVM` in contract files.
- Wired validations into CI and local tooling by updating `.github/workflows/sswg-mvm-ci.yml` to run the root contract checks and adding tasks in `scripts/local_ci.py` (`task_root_contract_validation`, `task_root_casing_lint`), and included an `ai_system_prompt.txt` that binds AI agents to these contracts.

### Testing
- No automated tests were executed as part of this change (no test run requested during rollout). 
- New schema-based validation is available via `scripts/validate_root_contracts.py` and will return non-zero on contract/schema mismatches when run in CI. 
- Casing enforcement is available via `scripts/lint_casing.py` and will return non-zero on violations when run in CI. 
- CI workflow `.github/workflows/sswg-mvm-ci.yml` was updated to invoke the root contract validation steps so future pushes/PRs will fail on contract or casing violations.
