### PR TITLE
Add meta-metrics scoring with baseline comparison and integrate dependency/inheritance checks

### DIFF
--- a/.github/workflows/sswg-mvm-ci.yml
+++ b/.github/workflows/sswg-mvm-ci.yml
@@ -66,6 +66,10 @@ jobs:
         run: |
           python -c "from ai_validation.schema_validator import validate_workflow; import json; import sys; wf=json.load(open('data/templates/campfire_workflow.json')); ok, errs=validate_workflow(wf); sys.exit(1 if not ok else 0)"
 
+      - name: PDL validation (example phase set)
+        run: |
+          python -m generator.pdl_validator pdl/example_full_9_phase.yaml
+
       - name: Root contract validation
         run: |
           python scripts/validate_root_contracts.py

--- a/ai_core/workflow.py
+++ b/ai_core/workflow.py
@@ -64,6 +64,10 @@ class Workflow:
         self.outputs: List[Dict[str, Any]] = []
         self.evaluation: Dict[str, Any] = {}
         self.recursion: Dict[str, Any] = {}
+        self.dependency_graph: Dict[str, Any] = {}
+        self.dependency_index: Dict[str, Any] = {}
+        self.causal_ledger: List[Dict[str, Any]] = []
+        self.inheritance: Dict[str, Any] = {}
         self.context: Dict[str, Any] = {}
 
         if args and isinstance(args[0], dict):
@@ -103,6 +107,10 @@ class Workflow:
         self.outputs = data.get("outputs", []) or []
         self.evaluation = data.get("evaluation", {}) or {}
         self.recursion = data.get("recursion", {}) or {}
+        self.dependency_graph = data.get("dependency_graph", {}) or {}
+        self.dependency_index = data.get("dependency_index", {}) or {}
+        self.causal_ledger = data.get("causal_ledger", []) or []
+        self.inheritance = data.get("inheritance", {}) or {}
 
         # Execution context can be stored in multiple places; we prefer a
         # dedicated field if present, otherwise we start empty.
@@ -222,6 +230,10 @@ class Workflow:
             "outputs": self.outputs,
             "evaluation": self.evaluation,
             "recursion": self.recursion,
+            "dependency_graph": self.dependency_graph,
+            "dependency_index": self.dependency_index,
+            "causal_ledger": self.causal_ledger,
+            "inheritance": self.inheritance,
             "context": self.context,
             "results": self.results,
             "params": self.params,

--- a/ai_evaluation/evaluation_engine.py
+++ b/ai_evaluation/evaluation_engine.py
@@ -42,9 +42,13 @@ def _register_default_metrics() -> None:
         return  # already initialized
 
     candidates = {
+        "clarity": getattr(qm, "clarity_metric", None),
         "coverage": getattr(qm, "coverage_metric", None),
         "coherence": getattr(qm, "coherence_metric", None),
+        "completeness": getattr(qm, "completeness_metric", None),
+        "intent_alignment": getattr(qm, "intent_alignment_metric", None),
         "specificity": getattr(qm, "specificity_metric", None),
+        "usability": getattr(qm, "usability_metric", None),
     }
 
     _METRICS = {name: func for name, func in candidates.items() if callable(func)}

--- a/generator/main.py
+++ b/generator/main.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import logging
 from copy import deepcopy
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional, Union
 
@@ -38,6 +39,7 @@ from ai_visualization.export_manager import export_markdown as viz_export_markdo
 from ai_core.orchestrator import Orchestrator
 from ai_core.workflow import Workflow
 from ai_evaluation.evaluation_engine import evaluate_workflow_quality
+from ai_memory.memory_store import MemoryStore
 from ai_memory.feedback_integrator import FeedbackIntegrator
 from ai_recursive.version_diff_engine import compute_diff_summary
 from data.data_parsing import load_template
@@ -53,6 +55,510 @@ handler = logging.StreamHandler()
 handler.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
 logger.addHandler(handler)
 logger.propagate = False
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _snapshot_dependencies(modules: list[dict[str, Any]]) -> dict[str, list[str]]:
+    snapshot: dict[str, list[str]] = {}
+    for module in modules:
+        module_id = module.get("module_id")
+        if not module_id:
+            continue
+        deps = [str(dep) for dep in (module.get("dependencies", []) or [])]
+        snapshot[str(module_id)] = deps
+    return snapshot
+
+
+def _build_dependency_graph(modules: list[dict[str, Any]]) -> dict[str, list[list[str]]]:
+    nodes = sorted(
+        {
+            str(module.get("module_id"))
+            for module in modules
+            if module.get("module_id")
+        }
+    )
+    edges: list[list[str]] = []
+    for module in modules:
+        module_id = module.get("module_id")
+        if not module_id:
+            continue
+        for dep in module.get("dependencies", []) or []:
+            edges.append([str(dep), str(module_id)])
+    return {"nodes": nodes, "edges": edges}
+
+
+def _build_dependency_index(
+    modules: list[dict[str, Any]],
+) -> dict[str, dict[str, list[str]]]:
+    module_ids = {
+        str(module.get("module_id"))
+        for module in modules
+        if module.get("module_id")
+    }
+    upstream: dict[str, list[str]] = {}
+    downstream: dict[str, list[str]] = {module_id: [] for module_id in module_ids}
+    missing: dict[str, list[str]] = {}
+
+    for module in modules:
+        module_id = module.get("module_id")
+        if not module_id:
+            continue
+        deps = [str(dep) for dep in (module.get("dependencies", []) or [])]
+        known = sorted([dep for dep in deps if dep in module_ids])
+        missing_deps = sorted([dep for dep in deps if dep not in module_ids])
+        upstream[str(module_id)] = known
+        if missing_deps:
+            missing[str(module_id)] = missing_deps
+        for dep in known:
+            downstream.setdefault(dep, []).append(str(module_id))
+
+    downstream = {key: sorted(value) for key, value in downstream.items()}
+    payload = {"upstream": upstream, "downstream": downstream}
+    if missing:
+        payload["missing"] = missing
+    return payload
+
+
+def _append_causal_entry(workflow: Dict[str, Any], entry: Dict[str, Any]) -> None:
+    ledger = workflow.setdefault("causal_ledger", [])
+    if isinstance(ledger, list):
+        ledger.append(entry)
+
+
+def _normalize_task_packaging(task: Dict[str, Any]) -> tuple[bool, Dict[str, Any]]:
+    updated = False
+    normalized = dict(task)
+    task_id = normalized.get("task_id") or normalized.get("id")
+    task_ref = normalized.get("task_ref")
+
+    if task_id and "task_id" not in normalized:
+        normalized["task_id"] = task_id
+        updated = True
+
+    if task_ref:
+        reuse = dict(normalized.get("reuse", {}))
+        if not reuse.get("mode"):
+            reuse["mode"] = "reference"
+        normalized["reuse"] = reuse
+        updated = True
+        return updated, normalized
+
+    if not task_id:
+        raise ValueError("Task is missing a stable id or task_ref.")
+
+    if not normalized.get("description") and normalized.get("action"):
+        normalized["description"] = f"Execute action: {normalized['action']}"
+        updated = True
+    if not normalized.get("description") and not normalized.get("action"):
+        raise ValueError(f"Task {task_id} is missing a description or action.")
+
+    prerequisites = normalized.get("prerequisites")
+    if prerequisites is None and normalized.get("inputs") is not None:
+        normalized["prerequisites"] = list(normalized.get("inputs") or [])
+        updated = True
+
+    expected_outputs = normalized.get("expected_outputs")
+    if expected_outputs is None and normalized.get("outputs") is not None:
+        normalized["expected_outputs"] = list(normalized.get("outputs") or [])
+        updated = True
+
+    if normalized.get("prerequisites") is None:
+        raise ValueError(f"Task {task_id} is missing prerequisites.")
+    if normalized.get("expected_outputs") is None:
+        raise ValueError(f"Task {task_id} is missing expected_outputs.")
+
+    reuse = dict(normalized.get("reuse", {}))
+    if reuse.get("mode") == "copy" and not reuse.get("justification"):
+        raise ValueError(f"Task {task_id} copy reuse requires justification.")
+    if reuse:
+        normalized["reuse"] = reuse
+
+    return updated, normalized
+
+
+def _apply_task_packaging(
+    workflow: Dict[str, Any],
+    *,
+    change_source: str,
+) -> None:
+    phases = workflow.get("phases", []) or []
+    changes: list[Dict[str, Any]] = []
+    for phase in phases:
+        tasks = phase.get("tasks")
+        if not isinstance(tasks, list):
+            continue
+        new_tasks: list[Dict[str, Any]] = []
+        for task in tasks:
+            if not isinstance(task, dict):
+                new_tasks.append(task)
+                continue
+            updated, normalized = _normalize_task_packaging(task)
+            new_tasks.append(normalized)
+            if updated:
+                changes.append(
+                    {
+                        "phase_id": phase.get("id") or phase.get("phase_id"),
+                        "task_id": normalized.get("task_id"),
+                    }
+                )
+        phase["tasks"] = new_tasks
+
+    if changes:
+        _append_causal_entry(
+            workflow,
+            {
+                "timestamp": _utc_timestamp(),
+                "change_type": "task_packaging_normalized",
+                "source": change_source,
+                "rationale": (
+                    "Ensure tasks declare stable ids, prerequisites, and expected outputs."
+                ),
+                "evidence": {
+                    "normalized_tasks": changes,
+                },
+                "impact_analysis": {
+                    "affected_tasks": [item["task_id"] for item in changes],
+                    "checks": [
+                        "task_id_present",
+                        "prerequisites_present",
+                        "expected_outputs_present",
+                    ],
+                },
+                "alternatives_considered": [
+                    "Allow implicit task contracts without normalization",
+                ],
+            },
+        )
+
+
+def _collect_tasks(workflow: Dict[str, Any]) -> dict[str, Dict[str, Any]]:
+    tasks_by_id: dict[str, Dict[str, Any]] = {}
+    for phase in workflow.get("phases", []) or []:
+        tasks = phase.get("tasks")
+        if not isinstance(tasks, list):
+            continue
+        for task in tasks:
+            if not isinstance(task, dict):
+                continue
+            task_id = task.get("task_id") or task.get("id")
+            if task_id:
+                tasks_by_id[str(task_id)] = task
+    return tasks_by_id
+
+
+def _collect_task_outputs(workflow: Dict[str, Any]) -> set[str]:
+    outputs: set[str] = set()
+    for phase in workflow.get("phases", []) or []:
+        tasks = phase.get("tasks")
+        if not isinstance(tasks, list):
+            continue
+        for task in tasks:
+            if not isinstance(task, dict):
+                continue
+            for output in task.get("expected_outputs", []) or []:
+                outputs.add(str(output))
+            for output in task.get("outputs", []) or []:
+                outputs.add(str(output))
+    return outputs
+
+
+def _apply_inheritance_checks(
+    workflow: Dict[str, Any],
+    *,
+    change_source: str,
+) -> None:
+    inheritance = workflow.get("inheritance")
+    if not isinstance(inheritance, dict) or not inheritance:
+        return
+
+    host_domain = inheritance.get("host_domain")
+    donor_domains = inheritance.get("donor_domains") or []
+    if not host_domain or not isinstance(donor_domains, list) or not donor_domains:
+        raise ValueError("Inheritance requires host_domain and donor_domains.")
+
+    conflict_rules = inheritance.get("conflict_rules") or {}
+    precedence = conflict_rules.get("precedence") or []
+    strategy = conflict_rules.get("strategy")
+    if not precedence or host_domain not in precedence or not strategy:
+        raise ValueError("Inheritance conflict_rules must define precedence and strategy.")
+
+    glossary = inheritance.get("glossary") or {}
+    if glossary:
+        term_map: dict[str, dict[str, str]] = {}
+        for domain, terms in glossary.items():
+            if not isinstance(terms, dict):
+                continue
+            for term, definition in terms.items():
+                term_map.setdefault(str(term), {})[str(domain)] = str(definition)
+
+        collisions: dict[str, dict[str, str]] = {}
+        for term, definitions in term_map.items():
+            unique_defs = set(definitions.values())
+            if len(definitions) > 1 and len(unique_defs) > 1:
+                collisions[term] = definitions
+
+        if collisions:
+            resolutions = inheritance.get("term_resolution") or {}
+            unresolved = {
+                term: defs
+                for term, defs in collisions.items()
+                if term not in resolutions
+            }
+            if unresolved:
+                raise ValueError(
+                    f"Unresolved term collisions in inheritance glossary: {sorted(unresolved)}"
+                )
+
+    imports = inheritance.get("imports") or []
+    tasks_by_id = _collect_tasks(workflow)
+    outputs = _collect_task_outputs(workflow)
+    prerequisite_overrides = set(
+        inheritance.get("prerequisite_overrides") or []
+    )
+
+    provenance_updates: list[dict[str, str]] = []
+    missing_prereqs: dict[str, list[str]] = {}
+
+    for item in imports:
+        if not isinstance(item, dict):
+            continue
+        domain = item.get("domain")
+        version = item.get("version")
+        if not domain or not version:
+            raise ValueError("Inheritance imports require domain and version.")
+        for task_id in item.get("task_ids", []) or []:
+            task = tasks_by_id.get(str(task_id))
+            if task is None:
+                raise ValueError(f"Imported task {task_id} not found in workflow.")
+            origin = task.get("origin") or {}
+            if origin.get("domain") != domain or origin.get("version") != version:
+                task["origin"] = {
+                    "domain": domain,
+                    "version": version,
+                    "source_task_id": str(task_id),
+                }
+                provenance_updates.append(
+                    {"task_id": str(task_id), "domain": str(domain)}
+                )
+
+            prereqs = task.get("prerequisites") or []
+            missing = [
+                str(req)
+                for req in prereqs
+                if str(req) not in outputs and str(req) not in prerequisite_overrides
+            ]
+            if missing:
+                missing_prereqs[str(task_id)] = missing
+
+    if missing_prereqs:
+        raise ValueError(
+            f"Imported tasks missing prerequisites: {sorted(missing_prereqs)}"
+        )
+
+    if provenance_updates:
+        _append_causal_entry(
+            workflow,
+            {
+                "timestamp": _utc_timestamp(),
+                "change_type": "inheritance_provenance_applied",
+                "source": change_source,
+                "rationale": "Ensure imported tasks carry origin domain/version.",
+                "evidence": {
+                    "provenance_updates": provenance_updates,
+                },
+                "impact_analysis": {
+                    "affected_tasks": [item["task_id"] for item in provenance_updates],
+                    "checks": [
+                        "origin_metadata_present",
+                        "inheritance_imports_validated",
+                    ],
+                },
+                "alternatives_considered": [
+                    "Allow imports without explicit provenance metadata",
+                ],
+            },
+        )
+
+
+def _apply_meta_metrics(
+    workflow: Dict[str, Any],
+    *,
+    quality_report: Dict[str, Any],
+) -> None:
+    workflow_id = workflow.get("workflow_id", "unnamed_workflow")
+    baseline_scores = None
+    baseline_overall = None
+    baseline_status = "missing"
+
+    baseline = MemoryStore().load_latest(str(workflow_id))
+    if baseline:
+        baseline_meta = baseline.get("evaluation", {}).get("meta_metrics", {})
+        baseline_scores = baseline_meta.get("scores")
+        baseline_overall = baseline_meta.get("overall_score")
+        if baseline_scores is None:
+            baseline_scores = baseline.get("evaluation", {}).get("quality", {}).get("metrics")
+            baseline_overall = baseline.get("evaluation", {}).get("quality", {}).get("overall_score")
+        if baseline_scores is not None:
+            baseline_status = "loaded"
+
+    scores = quality_report.get("metrics", {})
+    overall = quality_report.get("overall_score", 0.0)
+    deltas = {}
+    if baseline_scores:
+        for key, value in scores.items():
+            base_value = baseline_scores.get(key)
+            if base_value is not None:
+                deltas[key] = value - base_value
+
+    if baseline_overall is None and baseline_scores:
+        baseline_overall = sum(baseline_scores.values()) / max(len(baseline_scores), 1)
+
+    thresholds = {
+        "promotion_threshold": 0.02,
+        "regression_guard": -0.05,
+        "guard_metrics": [
+            "clarity",
+            "coherence",
+            "completeness",
+            "intent_alignment",
+            "usability",
+        ],
+    }
+
+    overall_delta = None
+    if baseline_overall is not None:
+        overall_delta = overall - baseline_overall
+
+    guard_metrics = thresholds["guard_metrics"]
+    regression_guard = thresholds["regression_guard"]
+    regression_guard_passed = True
+    if deltas:
+        regression_guard_passed = all(
+            deltas.get(metric, 0.0) >= regression_guard for metric in guard_metrics
+        )
+
+    promotion_threshold = thresholds["promotion_threshold"]
+    promotion_eligible = False
+    if overall_delta is not None:
+        promotion_eligible = overall_delta >= promotion_threshold and regression_guard_passed
+
+    meta_metrics = {
+        "timestamp": _utc_timestamp(),
+        "scores": scores,
+        "overall_score": overall,
+        "baseline": {
+            "status": baseline_status,
+            "overall_score": baseline_overall,
+            "scores": baseline_scores,
+        },
+        "deltas": {
+            "overall_score": overall_delta,
+            "metrics": deltas,
+        },
+        "thresholds": thresholds,
+        "decision": {
+            "promotion_eligible": promotion_eligible,
+            "regression_guard_passed": regression_guard_passed,
+        },
+        "evidence_notes": [
+            "Core metrics computed on the current workflow snapshot.",
+            "Baseline compared against latest stored workflow version.",
+        ],
+    }
+
+    workflow.setdefault("evaluation", {})["meta_metrics"] = meta_metrics
+
+
+def _apply_dependency_tracking(
+    workflow: Dict[str, Any],
+    *,
+    change_source: str,
+) -> None:
+    modules = workflow.get("modules", []) or []
+    module_ids = {
+        str(module.get("module_id"))
+        for module in modules
+        if module.get("module_id")
+    }
+    before_snapshot = _snapshot_dependencies(modules)
+    missing_dependencies = {
+        module_id: sorted([dep for dep in deps if dep not in module_ids])
+        for module_id, deps in before_snapshot.items()
+        if any(dep not in module_ids for dep in deps)
+    }
+
+    dg = DependencyGraph(modules)
+    dg.autocorrect_missing_dependencies()
+
+    cycle_detected = dg.detect_cycle()
+    cycle_corrected = False
+    if cycle_detected:
+        logger.warning("Dependency cycle detected; attempting autocorrect.")
+        cycle_corrected = dg.attempt_autocorrect_cycle()
+        if not cycle_corrected and workflow.get("evaluation") is not None:
+            workflow["evaluation"].setdefault("notes", []).append(
+                "Unresolved dependency cycle detected; manual review required.",
+            )
+
+    after_snapshot = _snapshot_dependencies(modules)
+    dependency_graph = _build_dependency_graph(modules)
+    dependency_index = _build_dependency_index(modules)
+    workflow["dependency_graph"] = dependency_graph
+    workflow["dependency_index"] = dependency_index
+
+    changes = {
+        module_id: {
+            "before": before_snapshot.get(module_id, []),
+            "after": after_snapshot.get(module_id, []),
+        }
+        for module_id in sorted(set(before_snapshot) | set(after_snapshot))
+        if before_snapshot.get(module_id, []) != after_snapshot.get(module_id, [])
+    }
+
+    if missing_dependencies or changes or cycle_detected:
+        affected_modules = sorted(changes.keys())
+        impacted_modules = sorted(
+            {
+                *affected_modules,
+                *[
+                    dep
+                    for module_id in affected_modules
+                    for dep in dependency_index.get("downstream", {}).get(module_id, [])
+                ],
+            }
+        )
+        _append_causal_entry(
+            workflow,
+            {
+                "timestamp": _utc_timestamp(),
+                "change_type": "dependency_autocorrect",
+                "source": change_source,
+                "rationale": (
+                    "Normalize dependency references and resolve cycles to keep "
+                    "execution ordering deterministic."
+                ),
+                "evidence": {
+                    "missing_dependencies": missing_dependencies,
+                    "cycle_detected": cycle_detected,
+                    "cycle_corrected": cycle_corrected,
+                    "changes": changes,
+                },
+                "impact_analysis": {
+                    "affected_modules": affected_modules,
+                    "downstream_impacts": impacted_modules,
+                    "checks": [
+                        "missing_dependency_scan",
+                        "dependency_cycle_check",
+                    ],
+                },
+                "alternatives_considered": [
+                    "Manual dependency remediation without autocorrect",
+                ],
+            },
+        )
 
 
 # ─── Optional telemetry integration ──────────────────────────────
@@ -202,7 +708,13 @@ def process_workflow(
     workflow_obj = Workflow(workflow)
     orchestrator.telemetry.record("loaded_via_orchestrator", {"workflow_id": workflow_obj.id})
 
-    # 1. Schema validation
+    # 1. Normalize task packaging for modular reuse
+    _apply_task_packaging(workflow, change_source="initial_pass")
+
+    # 2. Validate inheritance requirements for multi-domain workflows
+    _apply_inheritance_checks(workflow, change_source="initial_pass")
+
+    # 3. Schema validation
     ok, errors = validate_workflow(workflow)
     if not ok and errors:
         logger.warning("Initial schema validation reported %d issues.", len(errors))
@@ -211,28 +723,19 @@ def process_workflow(
             [],
         ).append("Schema validation reported issues; see logs for details.")
 
-    # 2. Build dependency graph and autocorrect structural issues
-    modules = workflow.get("modules", [])
-    dg = DependencyGraph(modules)
-    dg.autocorrect_missing_dependencies()
+    # 4. Build dependency graph and autocorrect structural issues
+    _apply_dependency_tracking(workflow, change_source="initial_pass")
 
-    if dg.detect_cycle():
-        logger.warning("Dependency cycle detected; attempting autocorrect.")
-        corrected = dg.attempt_autocorrect_cycle()
-        if not corrected and workflow.get("evaluation") is not None:
-            workflow["evaluation"].setdefault("notes", []).append(
-                "Unresolved dependency cycle detected; manual review required.",
-            )
-
-    # 3. Generate mermaid representation (for logging/debugging)
+    # 5. Generate mermaid representation (for logging/debugging)
     mermaid = mermaid_from_workflow(workflow)
     logger.info("Mermaid graph for workflow %s:\n%s", workflow_id, mermaid)
 
-    # 4. Evaluation + semantic scoring
+    # 6. Evaluation + semantic scoring
     base_quality = evaluate_workflow_quality(workflow)
     workflow.setdefault("evaluation", {})["quality"] = base_quality
+    _apply_meta_metrics(workflow, quality_report=base_quality)
 
-    # 5. Recursive refinement (single iteration) if enabled
+    # 7. Recursive refinement (single iteration) if enabled
     refined = deepcopy(workflow)
     if enable_refinement:
         recursion_manager = RecursionManager(output_dir=out_dir)
@@ -247,6 +750,35 @@ def process_workflow(
                 "plot": str(outcome.plot_path),
             }
         )
+        refined_quality = outcome.after_report.get("quality")
+        if isinstance(refined_quality, dict):
+            refined.setdefault("evaluation", {})["quality"] = refined_quality
+            _apply_meta_metrics(refined, quality_report=refined_quality)
+        diff_summary = compute_diff_summary(workflow, refined)
+        _append_causal_entry(
+            refined,
+            {
+                "timestamp": _utc_timestamp(),
+                "change_type": "workflow_refinement",
+                "source": "recursive_refinement",
+                "rationale": refined.get("recursion_metadata", {}).get(
+                    "llm_reasoning", "Refinement requested by recursion policy."
+                ),
+                "evidence": {
+                    "score_delta": outcome.score_delta,
+                    "semantic_delta": outcome.semantic_delta,
+                    "decision": refined.get("recursion_metadata", {}).get("llm_decision"),
+                    "diff_summary": diff_summary,
+                },
+                "impact_analysis": {
+                    "changed_fields": diff_summary.get("changed_fields", []),
+                    "checks": ["evaluation_delta", "semantic_delta"],
+                },
+                "alternatives_considered": [
+                    "Retain baseline workflow without refinement",
+                ],
+            },
+        )
         log_event(
             "mvm.process.refined",
             {
@@ -255,8 +787,11 @@ def process_workflow(
                 "semantic_delta": outcome.semantic_delta,
             },
         )
+        _apply_task_packaging(refined, change_source="refinement_pass")
+        _apply_inheritance_checks(refined, change_source="refinement_pass")
+        _apply_dependency_tracking(refined, change_source="refinement_pass")
 
-    # 6. Export updated visualization assets
+    # 8. Export updated visualization assets
     export_graphviz(refined, str(out_dir))
     viz_export_json(refined, str(out_dir))
     viz_export_markdown(refined, str(out_dir))

--- a/generator/pdl_validator.py
+++ b/generator/pdl_validator.py
@@ -7,6 +7,7 @@ emits deterministic failure labels on schema or IO errors.
 
 from __future__ import annotations
 
+import argparse
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -108,3 +109,32 @@ def validate_pdl_file(path: Path, schema_name: str = "pdl.json") -> None:
         ) from exc
 
     validate_pdl_object(pdl_obj, schema_name=schema_name)
+
+
+def _parse_args() -> Path:
+    parser = argparse.ArgumentParser(
+        description="Validate a PDL YAML file against the PDL schema.",
+    )
+    parser.add_argument(
+        "pdl_path",
+        type=Path,
+        help="Path to the PDL YAML file to validate.",
+    )
+    args = parser.parse_args()
+    return args.pdl_path
+
+
+def _main() -> int:
+    pdl_path = _parse_args()
+    try:
+        validate_pdl_file(pdl_path)
+    except PDLValidationError as exc:
+        label = exc.label.as_dict()
+        print(f"PDL validation failed: {label}")
+        return 1
+    print(f"PDL validation passed: {pdl_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/schemas/task_schema.json
+++ b/schemas/task_schema.json
@@ -3,9 +3,15 @@
   "title": "Task Schema",
   "description": "An instructional task within a phase.",
   "type": "object",
-  "required": ["description"],
+  "required": [],
   "properties": {
     "id": {
+      "type": "string"
+    },
+    "task_id": {
+      "type": "string"
+    },
+    "task_ref": {
       "type": "string"
     },
     "title": {
@@ -17,11 +23,22 @@
     "description": {
       "type": "string"
     },
+    "action": {
+      "type": "string"
+    },
     "inputs": {
       "type": "array",
       "items": { "type": "string" }
     },
+    "prerequisites": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
     "outputs": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "expected_outputs": {
       "type": "array",
       "items": { "type": "string" }
     },
@@ -31,15 +48,86 @@
     "human_actionable": {
       "type": "boolean"
     },
+    "task_type": {
+      "type": "string"
+    },
+    "origin": {
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "source_task_id": {
+          "type": "string"
+        }
+      },
+      "required": ["domain", "version"],
+      "additionalProperties": false
+    },
     "success_criteria": {
       "type": "string"
     },
     "notes": {
       "type": "string"
     },
+    "reuse": {
+      "type": "object",
+      "properties": {
+        "mode": {
+          "type": "string",
+          "enum": ["inline", "reference", "copy"]
+        },
+        "source_task_id": {
+          "type": "string"
+        },
+        "justification": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
+    },
+    "version": {
+      "type": "string"
+    },
      "metadata": {
       "$ref": "task_schema.json"
     }
   },
+  "anyOf": [
+    {
+      "required": ["task_ref"]
+    },
+    {
+      "allOf": [
+        {
+          "anyOf": [
+            { "required": ["id"] },
+            { "required": ["task_id"] }
+          ]
+        },
+        {
+          "anyOf": [
+            { "required": ["description"] },
+            { "required": ["action"] }
+          ]
+        },
+        {
+          "anyOf": [
+            { "required": ["prerequisites"] },
+            { "required": ["inputs"] }
+          ]
+        },
+        {
+          "anyOf": [
+            { "required": ["expected_outputs"] },
+            { "required": ["outputs"] }
+          ]
+        }
+      ]
+    }
+  ],
   "additionalProperties": false
 }


### PR DESCRIPTION
### Motivation
- Provide repeatable, decision-serving evaluation signals (clarity, coverage, coherence, specificity, completeness, intent alignment, usability) to detect regressions and support promotion/rollback decisions.
- Attach meta-metrics to workflow snapshots so refinements can be compared against a baseline and gated by promotion/regression thresholds.
- Strengthen pipeline robustness by normalizing task packaging, validating multi-domain inheritance provenance and prerequisite compatibility, and tracking dependency/causal changes.
- Make PDL validation and evaluation tooling runnable from the CLI and wire basic memory-backed baselines for comparisons.

### Description
- Added new scalar metrics in `ai_evaluation/quality_metrics.py`: `completeness_metric`, `intent_alignment_metric`, and `usability_metric`, plus a small stop-words set and token overlap heuristics.
- Extended `ai_evaluation/evaluation_engine.py` to register the new metrics (and `clarity`) so `evaluate_workflow_quality` returns the expanded metric set and overall score.
- Implemented meta-metrics baseline comparison and decision logic in `generator/main.py` via `_apply_meta_metrics`, which uses `ai_memory.MemoryStore` to load the latest snapshot, computes deltas, and records promotion/regression flags under `workflow["evaluation"]["meta_metrics"]`.
- Added task packaging normalization, dependency indexing/graph builders, inheritance/provenance checks, causal ledger entries, and integration points in the processing pipeline so packaging, inheritance, dependency tracking, evaluation, and meta-metrics are applied before and after refinement (new helpers: `_normalize_task_packaging`, `_apply_task_packaging`, `_apply_inheritance_checks`, `_apply_dependency_tracking`, `_append_causal_entry`, `_snapshot_dependencies`, `_build_dependency_index`, `_build_dependency_graph`, `_utc_timestamp`).
- Extended `ai_core/workflow.Workflow` to surface `dependency_graph`, `dependency_index`, `causal_ledger`, and `inheritance` in `to_dict`, and enhanced `ai_core/orchestrator.run` to record per-phase status and more detailed events.
- Added a CLI entrypoint to `generator/pdl_validator.py` so you can run `python -m generator.pdl_validator <pdl_path>`, and updated `schemas/task_schema.json` to support `task_id`/`task_ref`, `prerequisites`/`expected_outputs`, `origin` provenance, `reuse` metadata, and a validation `anyOf` that accepts either a `task_ref` or a fully-specified task contract.
- CI/workflow tweaks: example PDL validation step added to `.github/workflows/sswg-mvm-ci.yml` to run `python -m generator.pdl_validator pdl/example_full_9_phase.yaml` as part of the matrix.

### Testing
- No automated tests were executed locally as part of this change. 
- The repository CI is configured to run schema validation, `python -m generator.pdl_validator <pdl_path>`, root contract checks, and `pytest` on push/PR. 
- Basic runtime sanity was preserved by updating callers to use the new fields and helpers, and commits include the changes required for serialization and pipeline integration. 
- Reviewers should run `pytest` and the PDL validator locally or rely on CI to validate behavior before merging.
