### PR TITLE
Add remediation guidance for human-readable layer generation

### DIFF
--- a/docs/HUMAN_READABLE_LAYER.md
+++ b/docs/HUMAN_READABLE_LAYER.md
@@ -1,0 +1,275 @@
+sswg-mvm; version 1.0+ (living document)
+Date: 12-23-2025
+Document title: Remediation — Refine Human-Readable Layer Generation (Expanded)
+Author: Tommy Raven
+Licensing: Raven Recordings ©️ see: *LICENSE.md*
+(Document) Purpose: Define a remediation standard for the human-readable layer so instructional outputs remain executable, audience-aligned, and faithful to canonical logic while minimizing cognitive load.
+
+# Remediation — Refine Human-Readable Layer Generation (Expanded)
+
+## Why this remediation matters
+
+A recursive instructional system can be structurally perfect and still fail if humans cannot use what it produces. The human-readable layer is the “rendering” of the underlying instructional logic into text that real people can follow under real constraints: limited attention, incomplete context, varying expertise, and zero patience for ambiguity. This layer is not a cosmetic rewrite; it is an interface. If the interface is poor, the system’s true competence is effectively inaccessible.
+
+In practice, the human-readable layer is where the system proves it can act as a teacher rather than merely a compiler of instructions.
+
+---
+
+## A. Failure Modes if Ignored (Expanded)
+
+### 1) Outputs are technically correct but unusable
+
+**What this looks like**
+
+- Steps are logically sound but too abstract to execute (“prepare resources appropriately”).
+- The instruction lacks concrete decision points (“choose a method”) without selection criteria.
+- “Correct” content reads like policy language, not actionable guidance.
+
+**Why it happens**
+
+- The system optimizes for internal structure and completeness, not for execution by a human.
+- It assumes implied knowledge and omits “obvious” steps that aren’t obvious to novices.
+
+**What it breaks**
+
+- Adoption: users abandon the output even if it is correct.
+- Outcomes: users misapply steps or skip critical constraints.
+
+---
+
+### 2) High cognitive load and poor information architecture
+
+**What this looks like**
+
+- Dense blocks of text with nested conditions and no visual hierarchy.
+- Important constraints buried mid-paragraph.
+- Overlong sequences with no chunking, no checkpoints, no summaries.
+
+**Why it happens**
+
+- The system tries to preserve everything in one continuous stream.
+- No deliberate “progressive disclosure” (revealing complexity only when needed).
+
+**What it breaks**
+
+- Comprehension and retention.
+- Error rates rise because users miss critical details.
+
+---
+
+### 3) Loss of intent during translation from structured logic to prose
+
+**What this looks like**
+
+- The human-facing version subtly changes goals (“optimize X”) or constraints (“must not do Y”).
+- Nuanced rules become over-general (“always do…”), causing misapplication.
+- The system introduces new assumptions while trying to sound smooth.
+
+**Why it happens**
+
+- The rendering layer is treated as “creative writing” rather than faithful translation.
+- No fidelity checks between structured source and human output.
+
+**What it breaks**
+
+- Trust and correctness.
+- Accountability: the system can’t reliably guarantee that the human layer matches the canonical intent.
+
+---
+
+### 4) Tone and audience mismatch
+
+**What this looks like**
+
+- A novice-targeted artifact reads like graduate lecture notes.
+- An expert-targeted artifact reads like elementary scaffolding.
+- The user feels talked down to or left behind.
+
+**Why it happens**
+
+- Learner model is not embedded into the rendering process.
+- Tone defaults are not controlled.
+
+**What it breaks**
+
+- Engagement and adherence.
+- Perceived quality and professionalism.
+
+---
+
+## B. What “Good” Looks Like (Expanded)
+
+### 1) Faithful rendering: human-readable output preserves the canonical logic
+
+The human layer should be a loss-minimized projection of the structured source.
+
+**What “good” means**
+
+- Every required step in the structured logic appears in the human instructions.
+- Constraints are surfaced prominently, not buried.
+- No new requirements are invented; no critical requirements are omitted.
+- Conditional branches are expressed clearly, with explicit triggers.
+
+**Outcome**
+
+- The system can be audited: the human layer is demonstrably consistent with the underlying specification.
+
+---
+
+### 2) Progressive disclosure reduces cognitive load
+
+Humans need information in staged layers: first the path, then the details.
+
+**What “good” means**
+
+- Start with a short “what you’ll do” overview.
+- Provide step chunks with clear boundaries and completion criteria.
+- Defer advanced nuance until it becomes relevant (“if X happens, do Y”).
+- Offer optional deep dives for experts without forcing novices to read them.
+
+**Outcome**
+
+- Users can execute without being overwhelmed.
+- Advanced users still have full depth available.
+
+---
+
+### 3) Explicit decision points and success checks
+
+The best instructions are not just steps; they include how to know you’re doing it right.
+
+**What “good” means**
+
+Steps contain:
+
+- **Action** (do this)
+- **Reason** (why it matters, briefly)
+- **Check** (how to verify it worked)
+- **Failure response** (what to do if it didn’t)
+
+Decision points are framed as short, concrete branches.
+
+**Outcome**
+
+- Execution becomes robust under uncertainty.
+- Users can self-correct without external help.
+
+---
+
+### 4) Audience-adaptive style with consistent tone
+
+Human-readable content should feel designed for a specific reader.
+
+**What “good” means**
+
+- Vocabulary and assumed knowledge match the learner profile.
+- The document uses a consistent voice: instructional, not poetic; precise, not vague.
+- The system avoids “mood shifts” across sections.
+
+**Outcome**
+
+- Better engagement and adherence.
+- Lower risk of misinterpretation.
+
+---
+
+## C. The “Interface Contract” for Human-Readable Outputs
+
+A reliable human-readable layer behaves like a stable interface that never surprises the user.
+
+**Key contract elements**
+
+- Predictable structure: users learn where to find prerequisites, steps, checks, and troubleshooting.
+- Constraint visibility: “must-do/must-not-do” rules appear early and repeat where critical.
+- Terminology discipline: define new terms once, then reuse consistently.
+- Error-handling inclusion: user is never left without a next action.
+
+This contract is what makes outputs reusable over time.
+
+---
+
+## D. Common Design Patterns That Improve Usability (Conceptual)
+
+### 1) Checklist-first, explanation-second
+
+Humans often need execution speed first, theory later.
+
+- Provide a short checklist of steps.
+- Then expand each step with rationale and checks.
+
+### 2) “Golden path” plus optional branches
+
+Most users need the standard path; edge cases can be optional.
+
+- Present the default sequence.
+- Provide branches only when triggered.
+
+### 3) Guardrails as callouts (not buried prose)
+
+Rules that prevent failure should be visibly separated from narrative flow.
+
+### 4) Worked examples and anti-examples
+
+Examples teach faster than abstract rules, especially for novices.
+
+- Provide at least one “correct” example.
+- Provide one “common mistake” example and how to fix it.
+
+---
+
+## E. Fidelity risks: where human-readable generation tends to go wrong
+
+Even skilled systems commonly fail in predictable places:
+
+- Over-smoothing: removing necessary specificity to sound elegant.
+- Constraint dilution: translating “must” into “should.”
+- Implicit prerequisites: assuming the reader knows a step the system never stated.
+- Branch collapse: merging conditional paths into a single vague instruction.
+
+A refined human-readable layer anticipates these failure points and counters them structurally.
+
+---
+
+## F. Evaluation of the human-readable layer (ties directly to remediation 11)
+
+Once meta-metrics exist, they should apply here too.
+
+**High-signal checks**
+
+- “First-pass executability”: can a representative user follow it without questions?
+- Ambiguity count: how many steps require interpretation?
+- Constraint recall: can users correctly restate the key must/must-not rules after reading?
+- Time-to-first-success: how quickly a user can complete the first meaningful step.
+
+These tie readability to real outcomes rather than aesthetics.
+
+---
+
+## Minimum viable model (MVM) — the mental model
+
+The Minimum viable model (MVM) for human-readable layer refinement is:
+
+1. Two-layer output: a short overview/checklist + a detailed step-by-step expansion.
+2. Explicit checks per step: each step includes a verification cue (how to know it worked).
+3. Constraint surfacing rule: critical constraints appear in the first screenful and reappear at relevant steps.
+4. Fidelity check: confirm every structured requirement is represented in the human layer (no omissions, no inventions).
+
+This MVM ensures usability without turning documentation into a novel.
+
+---
+
+## mvm — the software posture (how it should behave)
+
+As mvm (software), the rendering layer should:
+
+- generate consistent document structure every time,
+- adapt vocabulary to learner profile,
+- include checks and failure responses by default,
+- run a fidelity pass against the underlying structured source,
+- score readability using the meta-metrics, and refuse promotion if usability regresses.
+
+---
+
+## Next remediation readiness
+
+Prepare to begin the next remediation after this: once humans can read the output, the system must also produce explainability that other agents can ingest without misapplying rules—human readability and cross-agent explainability are siblings, not rivals.


### PR DESCRIPTION
### Motivation
- Provide a remediation standard to make the human-readable rendering of workflows actionable, audience-aligned, and auditable. 
- Reduce cognitive load and preserve fidelity between structured logic and prose by surfacing constraints, checks, and decision points. 
- Establish an MVM-level contract so the renderer consistently produces a two-layer output with verification cues and fidelity checks.

### Description
- Add a new documentation file `docs/HUMAN_READABLE_LAYER.md` that documents failure modes, design patterns, the interface contract, fidelity risks, evaluation signals, and MVM expectations. 
- The document prescribes a two-layer output (short overview/checklist plus detailed expansion), explicit per-step checks, constraint-surfacing rules, and guidance for audience-adaptive tone. 
- This is a documentation-only change intended to guide future implementation of rendering, scoring, and promotion gates.

### Testing
- ⚠️ No automated tests were run because this is a documentation-only change. 
- ✅ The PR metadata was prepared by invoking `make_pr` with the new document referenced in the description.
