### PR TITLE
Add promotion gates for overlays, evaluation, provenance, env locking, and sswg-exp controls

### DIFF
--- a/docs/evaluation/evaluation_spec_template.json
+++ b/docs/evaluation/evaluation_spec_template.json
@@ -1,0 +1,40 @@
+{
+  "anchor": {
+    "anchor_id": "evaluation_spec",
+    "anchor_version": "1.0.0",
+    "scope": "iteration",
+    "owner": "docs.evaluation",
+    "status": "draft"
+  },
+  "eval_id": "example_eval",
+  "eval_version": "1.0.0",
+  "scope": "workflow",
+  "owner": "evaluation",
+  "success_criteria": {
+    "qualitative": [
+      "Outputs are auditable and deterministic where required.",
+      "Interpretive summaries reference measured artifacts."
+    ],
+    "quantitative": [
+      "Overall score meets minimum threshold.",
+      "Coverage remains above baseline tolerance."
+    ]
+  },
+  "metrics": [
+    { "name": "overall_score", "threshold": 0.6, "direction": "min" },
+    { "name": "coverage", "threshold": 0.55, "direction": "min" },
+    { "name": "clarity", "threshold": 0.55, "direction": "min" }
+  ],
+  "regression_definition": {
+    "tolerance": 0.02,
+    "description": "Any metric dropping more than tolerance is regression."
+  },
+  "rollback_plan": {
+    "artifact": "docs/evaluation/rollback_plan.md",
+    "steps": [
+      "Revert to the last canonical overlay chain.",
+      "Re-run evaluation against the baseline.",
+      "Document the regression cause in the evaluation report."
+    ]
+  }
+}

--- a/docs/evaluation/rollback_plan.md
+++ b/docs/evaluation/rollback_plan.md
@@ -1,0 +1,5 @@
+# Evaluation Rollback Plan
+
+1. Revert to the last canonical overlay chain.
+2. Re-run evaluation against the baseline metrics.
+3. Document the regression cause and remediation steps in the evaluation report.

--- a/docs/experiments/experiment_scope_template.json
+++ b/docs/experiments/experiment_scope_template.json
@@ -1,0 +1,20 @@
+{
+  "anchor": {
+    "anchor_id": "experiment_scope",
+    "anchor_version": "1.0.0",
+    "scope": "experiment",
+    "owner": "docs.experiments",
+    "status": "draft"
+  },
+  "exp_id": "example_exp",
+  "exp_version": "1.0.0",
+  "anchor_family": "sswg v1",
+  "owner": "experiments",
+  "scope": ["modules/", "schemas/"],
+  "exit_criteria": [
+    "Evaluation checkpoint passes against the baseline.",
+    "Provenance manifest is complete and anchored.",
+    "Reproducibility replay gate passes in clean environment."
+  ],
+  "graduation_ready": false
+}

--- a/docs/overlays/overlay_descriptor_template.json
+++ b/docs/overlays/overlay_descriptor_template.json
@@ -11,6 +11,8 @@
   ],
   "precedence": {
     "scope": "pdl",
+    "rules": "Explicit overlay precedence for PDL phase constraints.",
+    "order": 10,
     "notes": "Overlay applies only to PDL phase constraints."
   },
   "compatibility": {

--- a/evaluations/eval_spec.json
+++ b/evaluations/eval_spec.json
@@ -1,0 +1,40 @@
+{
+  "anchor": {
+    "anchor_id": "evaluation_spec",
+    "anchor_version": "1.0.0",
+    "scope": "iteration",
+    "owner": "evaluations",
+    "status": "draft"
+  },
+  "eval_id": "mvm_iteration_eval",
+  "eval_version": "1.0.0",
+  "scope": "promotion",
+  "owner": "evaluation",
+  "success_criteria": {
+    "qualitative": [
+      "Deterministic phases remain reproducible.",
+      "Interpretive summaries reference measured artifacts."
+    ],
+    "quantitative": [
+      "Overall score meets the minimum threshold.",
+      "Clarity and coverage remain above baseline tolerance."
+    ]
+  },
+  "metrics": [
+    { "name": "overall_score", "threshold": 0.6, "direction": "min" },
+    { "name": "clarity", "threshold": 0.55, "direction": "min" },
+    { "name": "coverage", "threshold": 0.55, "direction": "min" }
+  ],
+  "regression_definition": {
+    "tolerance": 0.02,
+    "description": "Any metric dropping more than tolerance is a regression."
+  },
+  "rollback_plan": {
+    "artifact": "docs/evaluation/rollback_plan.md",
+    "steps": [
+      "Revert to the last canonical overlay chain.",
+      "Re-run evaluation against the baseline metrics.",
+      "Document the regression cause and remediation steps in the evaluation report."
+    ]
+  }
+}

--- a/experiments/exp_scope.json
+++ b/experiments/exp_scope.json
@@ -1,0 +1,20 @@
+{
+  "anchor": {
+    "anchor_id": "experiment_scope",
+    "anchor_version": "1.0.0",
+    "scope": "experiment",
+    "owner": "experiments",
+    "status": "draft"
+  },
+  "exp_id": "mvm_experiment",
+  "exp_version": "0.1.0",
+  "anchor_family": "sswg v1",
+  "owner": "experiments",
+  "scope": ["overlays/", "evaluations/"],
+  "exit_criteria": [
+    "Evaluation checkpoint passes against baseline.",
+    "Provenance manifest and determinism reports are emitted.",
+    "Reproducibility replay gate passes using pinned dependencies."
+  ],
+  "graduation_ready": false
+}

--- a/generator/environment.py
+++ b/generator/environment.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+import platform
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+from importlib import metadata
+
+from generator.failure_emitter import FailureLabel
+from generator.hashing import hash_data
+
+
+def load_environment_lock(lock_path: Path) -> Dict[str, Any]:
+    return json.loads(lock_path.read_text(encoding="utf-8"))
+
+
+def compute_lock_hash(lock_path: Path) -> str:
+    payload = load_environment_lock(lock_path)
+    return hash_data(payload)
+
+
+def get_git_commit() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def environment_fingerprint(lock_path: Path, container_tag: str | None = None) -> Dict[str, Any]:
+    return {
+        "os": platform.system(),
+        "arch": platform.machine(),
+        "python_version": sys.version.split()[0],
+        "dependency_lock_hash": compute_lock_hash(lock_path),
+        "git_commit": get_git_commit(),
+        "container_tag": container_tag or "unknown",
+    }
+
+
+def check_environment_drift(lock_path: Path) -> FailureLabel | None:
+    lock = load_environment_lock(lock_path)
+    runtime = lock.get("runtime", {})
+    expected_python = runtime.get("python_version")
+    current_python = sys.version.split()[0]
+    drift: Dict[str, Any] = {}
+    if expected_python and expected_python != current_python:
+        drift["python_version"] = {"expected": expected_python, "actual": current_python}
+
+    missing: List[Dict[str, str]] = []
+    mismatched: List[Dict[str, str]] = []
+    for dependency in lock.get("dependencies", []):
+        name = dependency.get("name")
+        expected_version = dependency.get("version")
+        if not name or not expected_version:
+            continue
+        try:
+            actual_version = metadata.version(name)
+        except metadata.PackageNotFoundError:
+            missing.append({"name": name, "expected": expected_version})
+            continue
+        if actual_version != expected_version:
+            mismatched.append(
+                {
+                    "name": name,
+                    "expected": expected_version,
+                    "actual": actual_version,
+                }
+            )
+
+    if missing or mismatched:
+        drift["dependencies"] = {"missing": missing, "mismatched": mismatched}
+
+    if drift:
+        return FailureLabel(
+            Type="reproducibility_failure",
+            message="Environment drift detected against dependency lock",
+            phase_id="validate",
+            evidence=drift,
+        )
+
+    return None

--- a/generator/evaluation_spec.py
+++ b/generator/evaluation_spec.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from jsonschema import Draft202012Validator, RefResolver
+
+
+def _load_schema(schema_path: Path) -> Dict[str, Any]:
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+def get_evaluation_spec_validator(schema_dir: Path) -> Draft202012Validator:
+    schema = _load_schema(schema_dir / "evaluation-spec.json")
+    base_uri = schema_dir.as_uri().rstrip("/") + "/"
+    resolver = RefResolver(base_uri=base_uri, referrer=schema)
+    return Draft202012Validator(schema, resolver=resolver)
+
+
+def validate_evaluation_spec(
+    spec: Dict[str, Any],
+    *,
+    schema_dir: Path,
+    spec_path: Path | None = None,
+) -> List[Dict[str, Any]]:
+    validator = get_evaluation_spec_validator(schema_dir)
+    errors = sorted(validator.iter_errors(spec), key=lambda e: e.path)
+    return [
+        {
+            "message": error.message,
+            "path": list(error.path),
+            "schema_path": list(error.schema_path),
+            "spec_path": str(spec_path) if spec_path else None,
+        }
+        for error in errors
+    ]

--- a/generator/overlay_governance.py
+++ b/generator/overlay_governance.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+from jsonschema import Draft202012Validator, RefResolver
+
+
+def _load_schema(schema_path: Path) -> Dict[str, Any]:
+    return json.loads(schema_path.read_text(encoding="utf-8"))
+
+
+def get_overlay_validator(schema_dir: Path) -> Draft202012Validator:
+    schema = _load_schema(schema_dir / "overlay-descriptor.json")
+    base_uri = schema_dir.as_uri().rstrip("/") + "/"
+    resolver = RefResolver(base_uri=base_uri, referrer=schema)
+    return Draft202012Validator(schema, resolver=resolver)
+
+
+def validate_overlay_descriptor(
+    overlay: Dict[str, Any],
+    *,
+    schema_dir: Path,
+    overlay_path: Path | None = None,
+) -> List[Dict[str, Any]]:
+    validator = get_overlay_validator(schema_dir)
+    errors = sorted(validator.iter_errors(overlay), key=lambda e: e.path)
+    results: List[Dict[str, Any]] = [
+        {
+            "message": error.message,
+            "path": list(error.path),
+            "schema_path": list(error.schema_path),
+            "overlay_path": str(overlay_path) if overlay_path else None,
+        }
+        for error in errors
+    ]
+
+    operations = overlay.get("operations", [])
+    paths = [op.get("path") for op in operations if op.get("path")]
+    if len(paths) != len(set(paths)):
+        results.append(
+            {
+                "message": "Overlay contains duplicate operation paths, ambiguous interpretation.",
+                "path": ["operations"],
+                "schema_path": [],
+                "overlay_path": str(overlay_path) if overlay_path else None,
+            }
+        )
+
+    precedence = overlay.get("precedence", {})
+    scope = precedence.get("scope", "")
+    notes = precedence.get("notes", "")
+    rules = precedence.get("rules", "")
+    if not scope:
+        results.append(
+            {
+                "message": "Overlay precedence scope must be provided.",
+                "path": ["precedence", "scope"],
+                "schema_path": [],
+                "overlay_path": str(overlay_path) if overlay_path else None,
+            }
+        )
+    if not rules:
+        results.append(
+            {
+                "message": "Overlay precedence rules must be provided.",
+                "path": ["precedence", "rules"],
+                "schema_path": [],
+                "overlay_path": str(overlay_path) if overlay_path else None,
+            }
+        )
+    if scope == "global" and "explicit" not in notes.lower():
+        results.append(
+            {
+                "message": "Global overlay scope requires explicit precedence notes.",
+                "path": ["precedence", "notes"],
+                "schema_path": [],
+                "overlay_path": str(overlay_path) if overlay_path else None,
+            }
+        )
+
+    compatibility = overlay.get("compatibility", {})
+    if compatibility.get("status") == "breaking":
+        migration_plan = compatibility.get("migration_plan")
+        rollback_plan = compatibility.get("rollback_plan")
+        migration_steps = compatibility.get("migration_steps")
+        if not migration_plan:
+            results.append(
+                {
+                    "message": "Breaking overlays require a migration plan artifact path.",
+                    "path": ["compatibility", "migration_plan"],
+                    "schema_path": [],
+                    "overlay_path": str(overlay_path) if overlay_path else None,
+                }
+            )
+        if not rollback_plan:
+            results.append(
+                {
+                    "message": "Breaking overlays require a rollback plan artifact path.",
+                    "path": ["compatibility", "rollback_plan"],
+                    "schema_path": [],
+                    "overlay_path": str(overlay_path) if overlay_path else None,
+                }
+            )
+        if not migration_steps:
+            results.append(
+                {
+                    "message": "Breaking overlays require migration steps.",
+                    "path": ["compatibility", "migration_steps"],
+                    "schema_path": [],
+                    "overlay_path": str(overlay_path) if overlay_path else None,
+                }
+            )
+        if migration_plan and not Path(migration_plan).exists():
+            results.append(
+                {
+                    "message": "Migration plan artifact path does not exist.",
+                    "path": ["compatibility", "migration_plan"],
+                    "schema_path": [],
+                    "overlay_path": str(overlay_path) if overlay_path else None,
+                }
+            )
+        if rollback_plan and not Path(rollback_plan).exists():
+            results.append(
+                {
+                    "message": "Rollback plan artifact path does not exist.",
+                    "path": ["compatibility", "rollback_plan"],
+                    "schema_path": [],
+                    "overlay_path": str(overlay_path) if overlay_path else None,
+                }
+            )
+
+    return results
+
+
+def detect_overlay_ambiguity(overlays: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    errors: List[Dict[str, Any]] = []
+    scope_path_map: Dict[tuple[str, str], List[Dict[str, Any]]] = {}
+
+    for overlay in overlays:
+        overlay_id = overlay.get("overlay_id", "unknown")
+        precedence = overlay.get("precedence", {})
+        scope = precedence.get("scope", "")
+        order = precedence.get("order")
+        for operation in overlay.get("operations", []):
+            if operation.get("op") != "override":
+                continue
+            path = operation.get("path")
+            if not path:
+                continue
+            key = (scope, path)
+            scope_path_map.setdefault(key, []).append(
+                {"overlay_id": overlay_id, "order": order}
+            )
+
+    for (scope, path), entries in scope_path_map.items():
+        if len(entries) <= 1:
+            continue
+        orders = [entry.get("order") for entry in entries]
+        if any(order is None for order in orders) or len(set(orders)) != len(orders):
+            errors.append(
+                {
+                    "message": "Ambiguous override ordering detected for overlay precedence.",
+                    "scope": scope,
+                    "path": path,
+                    "overlay_ids": [entry["overlay_id"] for entry in entries],
+                }
+            )
+
+    return errors
+
+
+def build_overlay_promotion_report(
+    overlays: List[Dict[str, Any]],
+    *,
+    lint_errors: Dict[str, List[Dict[str, Any]]],
+    ambiguity_errors: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    ambiguity_map: Dict[str, List[Dict[str, Any]]] = {}
+    for error in ambiguity_errors:
+        for overlay_id in error.get("overlay_ids", []):
+            ambiguity_map.setdefault(overlay_id, []).append(error)
+
+    overlay_reports = []
+    for overlay in overlays:
+        overlay_id = overlay.get("overlay_id", "unknown")
+        compatibility = overlay.get("compatibility", {})
+        migration_present = compatibility.get("status") != "breaking" or all(
+            compatibility.get(key)
+            for key in ("migration_plan", "migration_steps", "rollback_plan")
+        )
+        overlay_reports.append(
+            {
+                "overlay_id": overlay_id,
+                "overlay_version": overlay.get("overlay_version", ""),
+                "scope": overlay.get("precedence", {}).get("scope", ""),
+                "compat": compatibility.get("status", ""),
+                "migration_present": migration_present,
+                "lint_pass": not lint_errors.get(overlay_id, []),
+                "ambiguity_pass": not ambiguity_map.get(overlay_id, []),
+            }
+        )
+
+    return {
+        "anchor": {
+            "anchor_id": "overlay_promotion_report",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "generator.overlay_governance",
+            "status": "draft",
+        },
+        "overlays": overlay_reports,
+    }

--- a/reproducibility/dependency_lock.json
+++ b/reproducibility/dependency_lock.json
@@ -1,0 +1,143 @@
+{
+  "anchor": {
+    "anchor_id": "environment_lock",
+    "anchor_version": "1.0.0",
+    "scope": "runtime",
+    "owner": "reproducibility",
+    "status": "draft"
+  },
+  "runtime": {
+    "python_version": "3.11.12"
+  },
+  "dependencies": [
+    {
+      "name": "attrs",
+      "version": "24.2.0"
+    },
+    {
+      "name": "black",
+      "version": "25.9.0"
+    },
+    {
+      "name": "certifi",
+      "version": "2024.8.30"
+    },
+    {
+      "name": "click",
+      "version": "8.1.7"
+    },
+    {
+      "name": "gitdb",
+      "version": "4.0.11"
+    },
+    {
+      "name": "GitPython",
+      "version": "3.1.43"
+    },
+    {
+      "name": "iniconfig",
+      "version": "2.3.0"
+    },
+    {
+      "name": "isort",
+      "version": "7.0.0"
+    },
+    {
+      "name": "jsonschema",
+      "version": "4.23.0"
+    },
+    {
+      "name": "jsonschema-specifications",
+      "version": "2025.9.1"
+    },
+    {
+      "name": "markdown-it-py",
+      "version": "3.0.0"
+    },
+    {
+      "name": "mdurl",
+      "version": "0.1.2"
+    },
+    {
+      "name": "mypy",
+      "version": "1.18.2"
+    },
+    {
+      "name": "mypy_extensions",
+      "version": "1.1.0"
+    },
+    {
+      "name": "nodeenv",
+      "version": "1.9.1"
+    },
+    {
+      "name": "packaging",
+      "version": "25.0"
+    },
+    {
+      "name": "pathspec",
+      "version": "0.12.1"
+    },
+    {
+      "name": "platformdirs",
+      "version": "4.5.0"
+    },
+    {
+      "name": "pluggy",
+      "version": "1.6.0"
+    },
+    {
+      "name": "Pygments",
+      "version": "2.18.0"
+    },
+    {
+      "name": "pyright",
+      "version": "1.1.406"
+    },
+    {
+      "name": "pytest",
+      "version": "8.4.2"
+    },
+    {
+      "name": "pytokens",
+      "version": "0.2.0"
+    },
+    {
+      "name": "PyYAML",
+      "version": "6.0.2"
+    },
+    {
+      "name": "referencing",
+      "version": "0.33.0"
+    },
+    {
+      "name": "rich",
+      "version": "13.7.1"
+    },
+    {
+      "name": "rpds-py",
+      "version": "0.18.1"
+    },
+    {
+      "name": "ruff",
+      "version": "0.14.2"
+    },
+    {
+      "name": "shellingham",
+      "version": "1.5.4"
+    },
+    {
+      "name": "smmap",
+      "version": "5.0.1"
+    },
+    {
+      "name": "typer",
+      "version": "0.12.3"
+    },
+    {
+      "name": "typing_extensions",
+      "version": "4.15.0"
+    }
+  ],
+  "notes": "Pinned dependency lock generated from pip freeze."
+}

--- a/schemas/environment-lock.json
+++ b/schemas/environment-lock.json
@@ -1,0 +1,48 @@
+{
+  "$id": "https://schemas.sswg.local/environment-lock.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg environment lock",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["anchor", "runtime", "dependencies"],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "sandbox", "canonical", "archived"]
+        }
+      }
+    },
+    "runtime": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["python_version"],
+      "properties": {
+        "python_version": { "type": "string" }
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "version"],
+        "properties": {
+          "name": { "type": "string" },
+          "version": { "type": "string" },
+          "hash": { "type": "string" }
+        }
+      }
+    },
+    "notes": { "type": "string" }
+  }
+}

--- a/schemas/evaluation-spec.json
+++ b/schemas/evaluation-spec.json
@@ -1,0 +1,90 @@
+{
+  "$id": "https://schemas.sswg.local/evaluation-spec.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg evaluation spec",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "anchor",
+    "eval_id",
+    "eval_version",
+    "scope",
+    "owner",
+    "success_criteria",
+    "metrics",
+    "regression_definition",
+    "rollback_plan"
+  ],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "sandbox", "canonical", "archived"]
+        }
+      }
+    },
+    "eval_id": { "type": "string" },
+    "eval_version": { "type": "string" },
+    "scope": { "type": "string" },
+    "owner": { "type": "string" },
+    "success_criteria": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["qualitative", "quantitative"],
+      "properties": {
+        "qualitative": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "quantitative": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "metrics": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "threshold", "direction"],
+        "properties": {
+          "name": { "type": "string" },
+          "threshold": { "type": "number" },
+          "direction": { "type": "string", "enum": ["min", "max"] }
+        }
+      }
+    },
+    "regression_definition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tolerance", "description"],
+      "properties": {
+        "tolerance": { "type": "number", "minimum": 0 },
+        "description": { "type": "string" }
+      }
+    },
+    "rollback_plan": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["artifact", "steps"],
+      "properties": {
+        "artifact": { "type": "string" },
+        "steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/experiment-scope.json
+++ b/schemas/experiment-scope.json
@@ -1,0 +1,49 @@
+{
+  "$id": "https://schemas.sswg.local/experiment-scope.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg experiment scope",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "anchor",
+    "exp_id",
+    "exp_version",
+    "anchor_family",
+    "owner",
+    "scope",
+    "exit_criteria",
+    "graduation_ready"
+  ],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "sandbox", "canonical", "archived"]
+        }
+      }
+    },
+    "exp_id": { "type": "string" },
+    "exp_version": { "type": "string" },
+    "anchor_family": { "type": "string" },
+    "owner": { "type": "string" },
+    "scope": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "exit_criteria": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "graduation_ready": { "type": "boolean" }
+  }
+}

--- a/schemas/overlay-descriptor.json
+++ b/schemas/overlay-descriptor.json
@@ -36,9 +36,11 @@
     "precedence": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["scope"],
+      "required": ["scope", "rules"],
       "properties": {
-        "scope": { "type": "string" },
+        "scope": { "type": "string", "minLength": 1 },
+        "rules": { "type": "string", "minLength": 1 },
+        "order": { "type": "integer", "minimum": 0 },
         "notes": { "type": "string" }
       }
     },
@@ -51,7 +53,13 @@
           "type": "string",
           "enum": ["backward", "forward", "breaking"]
         },
-        "migration_plan": { "type": "string" }
+        "migration_plan": { "type": "string" },
+        "migration_steps": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" }
+        },
+        "rollback_plan": { "type": "string" }
       }
     }
   },
@@ -66,7 +74,7 @@
       },
       "then": {
         "properties": {
-          "compatibility": { "required": ["migration_plan"] }
+          "compatibility": { "required": ["migration_plan", "migration_steps", "rollback_plan"] }
         }
       }
     }

--- a/schemas/provenance-manifest.json
+++ b/schemas/provenance-manifest.json
@@ -1,0 +1,89 @@
+{
+  "$id": "https://schemas.sswg.local/provenance-manifest.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg provenance manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "anchor",
+    "run_id",
+    "inputs_hash",
+    "pdl_ref",
+    "schema_refs",
+    "overlay_chain",
+    "phase_handlers",
+    "artifacts"
+  ],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": {
+          "type": "string",
+          "enum": ["draft", "sandbox", "canonical", "archived"]
+        }
+      }
+    },
+    "run_id": { "type": "string" },
+    "inputs_hash": { "type": "string" },
+    "pdl_ref": { "type": "string" },
+    "schema_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["schema_id", "content_hash"],
+        "properties": {
+          "schema_id": { "type": "string" },
+          "content_hash": { "type": "string" }
+        }
+      }
+    },
+    "overlay_chain": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["overlay_id", "overlay_version"],
+        "properties": {
+          "overlay_id": { "type": "string" },
+          "overlay_version": { "type": "string" }
+        }
+      }
+    },
+    "phase_handlers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["phase", "handler"],
+        "properties": {
+          "phase": { "type": "string" },
+          "handler": { "type": "string" }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["path", "hash"],
+        "properties": {
+          "path": { "type": "string" },
+          "hash": { "type": "string" },
+          "anchor": { "type": "object" }
+        }
+      }
+    }
+  }
+}

--- a/scripts/check_environment_drift.py
+++ b/scripts/check_environment_drift.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from generator.environment import check_environment_drift
+from generator.failure_emitter import FailureEmitter
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Check environment drift against dependency lock.")
+    parser.add_argument(
+        "--lock-path",
+        type=Path,
+        default=Path("reproducibility/dependency_lock.json"),
+        help="Dependency lock path.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default="local-run",
+        help="Run identifier for failure logs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    failure = check_environment_drift(args.lock_path)
+    if failure:
+        FailureEmitter(Path("artifacts/failures")).emit(failure, run_id=args.run_id)
+        print(f"Environment drift detected: {failure.as_dict()}")
+        return 1
+
+    print("Environment drift check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/overlay_governance_validation.py
+++ b/scripts/overlay_governance_validation.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from generator.failure_emitter import FailureEmitter, FailureLabel
+from generator.overlay_governance import (
+    build_overlay_promotion_report,
+    detect_overlay_ambiguity,
+    validate_overlay_descriptor,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Overlay governance validation gate.")
+    parser.add_argument(
+        "--overlays-dir",
+        type=Path,
+        default=Path("overlays"),
+        help="Overlay descriptor directory.",
+    )
+    parser.add_argument(
+        "--schema-dir",
+        type=Path,
+        default=Path("schemas"),
+        help="Schema directory.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default="local-run",
+        help="Run identifier for failure logs.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/overlays/overlay_promotion_report.json"),
+        help="Output path for overlay promotion report.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    overlays = []
+    lint_errors: dict[str, list[dict[str, object]]] = {}
+
+    if args.overlays_dir.exists():
+        for path in sorted(args.overlays_dir.glob("*.json")):
+            overlay = json.loads(path.read_text(encoding="utf-8"))
+            overlays.append(overlay)
+            errors = validate_overlay_descriptor(
+                overlay,
+                schema_dir=args.schema_dir,
+                overlay_path=path,
+            )
+            if errors:
+                overlay_id = overlay.get("overlay_id", path.stem)
+                lint_errors.setdefault(overlay_id, []).extend(errors)
+
+    ambiguity_errors = detect_overlay_ambiguity(overlays)
+    report = build_overlay_promotion_report(
+        overlays,
+        lint_errors=lint_errors,
+        ambiguity_errors=ambiguity_errors,
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    if lint_errors or ambiguity_errors:
+        failure = FailureLabel(
+            Type="schema_failure",
+            message="Overlay governance validation failed",
+            phase_id="validate",
+            evidence={
+                "lint_errors": lint_errors,
+                "ambiguity_errors": ambiguity_errors,
+            },
+        )
+        FailureEmitter(Path("artifacts/failures")).emit(failure, run_id=args.run_id)
+        print(f"Overlay governance validation failed: {failure.as_dict()}")
+        return 1
+
+    print(f"Overlay governance validation passed: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/replay_determinism_gate.py
+++ b/scripts/replay_determinism_gate.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from generator.determinism import replay_determinism_check, write_determinism_report
+from generator.failure_emitter import FailureEmitter
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run deterministic replay gate.")
+    parser.add_argument(
+        "--phase-outputs",
+        type=Path,
+        default=Path("tests/fixtures/phase_outputs.json"),
+        help="Phase outputs fixture.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default="local-run",
+        help="Run identifier.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("artifacts/evidence_pack/determinism_report.json"),
+        help="Output path for determinism report.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    phase_outputs = json.loads(args.phase_outputs.read_text(encoding="utf-8"))
+    failure, report = replay_determinism_check(
+        run_id=args.run_id,
+        phase_outputs=phase_outputs,
+        required_phases=["normalize", "analyze", "validate", "compare"],
+    )
+    write_determinism_report(args.output, report)
+    if failure:
+        FailureEmitter(Path("artifacts/failures")).emit(failure, run_id=args.run_id)
+        print(f"Determinism replay gate failed: {failure.as_dict()}")
+        return 1
+
+    print(f"Determinism replay gate passed: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_evaluation_checkpoint.py
+++ b/scripts/run_evaluation_checkpoint.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict
+
+from ai_evaluation.checkpoints import EvaluationCheckpointer
+from generator.evaluation_spec import validate_evaluation_spec
+from generator.failure_emitter import FailureEmitter, FailureLabel
+from generator.hashing import hash_data
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run evaluation checkpoint gate.")
+    parser.add_argument(
+        "--eval-spec",
+        type=Path,
+        default=Path("evaluations/eval_spec.json"),
+        help="Evaluation spec path.",
+    )
+    parser.add_argument(
+        "--baseline",
+        type=Path,
+        default=Path("tests/fixtures/eval_baseline.json"),
+        help="Baseline metrics JSON.",
+    )
+    parser.add_argument(
+        "--candidate",
+        type=Path,
+        default=Path("tests/fixtures/eval_candidate.json"),
+        help="Candidate metrics JSON.",
+    )
+    parser.add_argument(
+        "--schema-dir",
+        type=Path,
+        default=Path("schemas"),
+        help="Schema directory.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("artifacts/evaluation"),
+        help="Output directory for evaluation artifacts.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default="local-run",
+        help="Run identifier.",
+    )
+    parser.add_argument(
+        "--allow-breaking-override",
+        action="store_true",
+        help="Allow breaking overlay override for regressions.",
+    )
+    return parser.parse_args()
+
+
+def _load_metrics(path: Path) -> Dict[str, float]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return {k: float(v) for k, v in payload.get("metrics", {}).items()}
+
+
+def main() -> int:
+    args = _parse_args()
+    failure_emitter = FailureEmitter(Path("artifacts/failures"))
+
+    if not args.eval_spec.exists():
+        failure = FailureLabel(
+            Type="reproducibility_failure",
+            message="Evaluation spec is missing",
+            phase_id="validate",
+            evidence={"path": str(args.eval_spec)},
+        )
+        failure_emitter.emit(failure, run_id=args.run_id)
+        print(f"Evaluation checkpoint failed: {failure.as_dict()}")
+        return 1
+
+    spec = json.loads(args.eval_spec.read_text(encoding="utf-8"))
+    errors = validate_evaluation_spec(spec, schema_dir=args.schema_dir, spec_path=args.eval_spec)
+    if errors:
+        failure = FailureLabel(
+            Type="schema_failure",
+            message="Evaluation spec validation failed",
+            phase_id="validate",
+            evidence={"errors": errors},
+        )
+        failure_emitter.emit(failure, run_id=args.run_id)
+        print(f"Evaluation checkpoint failed: {failure.as_dict()}")
+        return 1
+    rollback_artifact = spec.get("rollback_plan", {}).get("artifact")
+    if rollback_artifact and not Path(rollback_artifact).exists():
+        failure = FailureLabel(
+            Type="reproducibility_failure",
+            message="Evaluation rollback plan artifact is missing",
+            phase_id="validate",
+            evidence={"path": rollback_artifact},
+        )
+        failure_emitter.emit(failure, run_id=args.run_id)
+        print(f"Evaluation checkpoint failed: {failure.as_dict()}")
+        return 1
+
+    criteria = {metric["name"]: metric["threshold"] for metric in spec.get("metrics", [])}
+    tolerance = float(spec.get("regression_definition", {}).get("tolerance", 0.0))
+    checkpointer = EvaluationCheckpointer(success_criteria=criteria, tolerance=tolerance)
+
+    baseline_metrics = _load_metrics(args.baseline)
+    candidate_metrics = _load_metrics(args.candidate)
+
+    checkpointer.record("baseline", baseline_metrics)
+    candidate_checkpoint = checkpointer.record("candidate", candidate_metrics)
+
+    deltas = {
+        name: candidate_metrics.get(name, 0.0) - baseline_metrics.get(name, 0.0)
+        for name in set(baseline_metrics) | set(candidate_metrics)
+    }
+
+    override_used = False
+    if not candidate_checkpoint.passed and args.allow-breaking-override:
+        override_used = True
+
+    report = {
+        "anchor": {
+            "anchor_id": "evaluation_report",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "scripts.run_evaluation_checkpoint",
+            "status": "draft",
+        },
+        "run_id": args.run_id,
+        "eval_id": spec.get("eval_id"),
+        "eval_version": spec.get("eval_version"),
+        "baseline": baseline_metrics,
+        "candidate": candidate_metrics,
+        "deltas": deltas,
+        "passed": candidate_checkpoint.passed,
+        "regressions": candidate_checkpoint.regressions,
+        "rollback_recommended": candidate_checkpoint.rollback_recommended,
+        "override_used": override_used,
+        "inputs_hash": hash_data({"baseline": baseline_metrics, "candidate": candidate_metrics}),
+    }
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    report_path = args.output_dir / "eval_report.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    interpret_notes = json.loads(args.candidate.read_text(encoding="utf-8")).get(
+        "interpretive_notes", []
+    )
+    variance_payload = {
+        "anchor": {
+            "anchor_id": "interpret_variance_notes",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "scripts.run_evaluation_checkpoint",
+            "status": "draft",
+        },
+        "run_id": args.run_id,
+        "notes": interpret_notes,
+    }
+    variance_path = args.output_dir / "interpret_variance_notes.json"
+    variance_path.write_text(json.dumps(variance_payload, indent=2), encoding="utf-8")
+
+    if not candidate_checkpoint.passed and not override_used:
+        failure = FailureLabel(
+            Type="reproducibility_failure",
+            message="Evaluation checkpoint failed",
+            phase_id="validate",
+            evidence={"report": str(report_path)},
+        )
+        failure_emitter.emit(failure, run_id=args.run_id)
+        print(f"Evaluation checkpoint failed: {failure.as_dict()}")
+        return 1
+
+    print(f"Evaluation checkpoint passed: {report_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_promotion_readiness.py
+++ b/scripts/run_promotion_readiness.py
@@ -4,6 +4,8 @@ import argparse
 import json
 from pathlib import Path
 
+from ai_evaluation.checkpoints import EvaluationCheckpointer
+from jsonschema import Draft202012Validator
 from generator.determinism import (
     bijectivity_check,
     replay_determinism_check,
@@ -14,7 +16,14 @@ from generator.failure_emitter import FailureEmitter, FailureLabel, validate_fai
 from generator.pdl_validator import PDLValidationError, validate_pdl_file_with_report
 from generator.phase_io import build_phase_io_manifest, detect_phase_collapse, load_pdl, write_manifest
 from generator.anchor_registry import AnchorRegistry, enforce_anchor
+from generator.environment import check_environment_drift, environment_fingerprint
+from generator.evaluation_spec import validate_evaluation_spec
 from generator.hashing import hash_data
+from generator.overlay_governance import (
+    build_overlay_promotion_report,
+    detect_overlay_ambiguity,
+    validate_overlay_descriptor,
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -62,6 +71,24 @@ def _parse_args() -> argparse.Namespace:
         help="Evidence pack output directory.",
     )
     parser.add_argument(
+        "--eval-spec",
+        type=Path,
+        default=Path("evaluations/eval_spec.json"),
+        help="Evaluation spec path.",
+    )
+    parser.add_argument(
+        "--eval-baseline",
+        type=Path,
+        default=Path("tests/fixtures/eval_baseline.json"),
+        help="Baseline evaluation metrics JSON.",
+    )
+    parser.add_argument(
+        "--eval-candidate",
+        type=Path,
+        default=Path("tests/fixtures/eval_candidate.json"),
+        help="Candidate evaluation metrics JSON.",
+    )
+    parser.add_argument(
         "--anchor-registry",
         type=Path,
         default=Path("config/anchor_registry.json"),
@@ -73,6 +100,25 @@ def _parse_args() -> argparse.Namespace:
         default=Path("overlays"),
         help="Overlay descriptor directory.",
     )
+    parser.add_argument(
+        "--lock-path",
+        type=Path,
+        default=Path("reproducibility/dependency_lock.json"),
+        help="Dependency lock path.",
+    )
+    parser.add_argument(
+        "--release-track",
+        type=str,
+        default="sswg",
+        choices=["sswg", "sswg-exp", "sswg-trs"],
+        help="Release track for promotion gating.",
+    )
+    parser.add_argument(
+        "--experiment-scope",
+        type=Path,
+        default=Path("experiments/exp_scope.json"),
+        help="Experiment scope declaration path.",
+    )
     return parser.parse_args()
 
 
@@ -80,6 +126,32 @@ def _gate_failure(emitter: FailureEmitter, run_id: str, failure: FailureLabel) -
     emitter.emit(failure, run_id=run_id)
     print(f"Promotion readiness gate failed: {failure.as_dict()}")
     return 1
+
+
+def _load_metrics(path: Path) -> dict[str, float]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return {name: float(value) for name, value in payload.get("metrics", {}).items()}
+
+
+def _has_breaking_override(overlays: list[dict]) -> bool:
+    for overlay in overlays:
+        compatibility = overlay.get("compatibility", {})
+        if compatibility.get("status") == "breaking":
+            if all(
+                compatibility.get(key)
+                for key in ("migration_plan", "migration_steps", "rollback_plan")
+            ):
+                return True
+    return False
+
+
+def _collect_artifact_entry(path: Path) -> dict:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "path": str(path),
+        "hash": hash_data(payload),
+        "anchor": payload.get("anchor", {}),
+    }
 
 
 def main() -> int:
@@ -145,7 +217,7 @@ def main() -> int:
 
     registry = AnchorRegistry(args.anchor_registry)
     registry_data = registry.load()
-    overlays = []
+    overlays: list[dict] = []
     if args.overlays_dir.exists():
         overlays = [
             json.loads(path.read_text(encoding="utf-8"))
@@ -164,10 +236,367 @@ def main() -> int:
         "overlays": overlays,
     }
     overlay_payload["inputs_hash"] = hash_data(overlay_payload)
-    (evidence_dir / "overlay_chain_manifest.json").write_text(
+    overlay_manifest_path = evidence_dir / "overlay_chain_manifest.json"
+    overlay_manifest_path.write_text(
         json.dumps(overlay_payload, indent=2),
         encoding="utf-8",
     )
+
+    overlay_lint_errors: dict[str, list[dict[str, object]]] = {}
+    for overlay_path in sorted(args.overlays_dir.glob("*.json")) if args.overlays_dir.exists() else []:
+        overlay = json.loads(overlay_path.read_text(encoding="utf-8"))
+        errors = validate_overlay_descriptor(
+            overlay,
+            schema_dir=args.schema_dir,
+            overlay_path=overlay_path,
+        )
+        if errors:
+            overlay_id = overlay.get("overlay_id", overlay_path.stem)
+            overlay_lint_errors.setdefault(overlay_id, []).extend(errors)
+
+    ambiguity_errors = detect_overlay_ambiguity(overlays)
+    overlay_report = build_overlay_promotion_report(
+        overlays,
+        lint_errors=overlay_lint_errors,
+        ambiguity_errors=ambiguity_errors,
+    )
+    overlay_report_path = evidence_dir / "overlay_promotion_report.json"
+    overlay_report_path.write_text(json.dumps(overlay_report, indent=2), encoding="utf-8")
+
+    if overlay_lint_errors or ambiguity_errors:
+        return _gate_failure(
+            failure_emitter,
+            args.run_id,
+            FailureLabel(
+                Type="schema_failure",
+                message="Overlay governance validation failed",
+                phase_id="validate",
+                evidence={
+                    "lint_errors": overlay_lint_errors,
+                    "ambiguity_errors": ambiguity_errors,
+                },
+            ),
+        )
+
+    if args.release_track == "sswg-exp":
+        global_overrides = [
+            overlay
+            for overlay in overlays
+            if overlay.get("precedence", {}).get("scope") == "global"
+        ]
+        if global_overrides:
+            for overlay in global_overrides:
+                notes = overlay.get("precedence", {}).get("notes", "")
+                if "exp-approved" not in notes.lower():
+                    return _gate_failure(
+                        failure_emitter,
+                        args.run_id,
+                        FailureLabel(
+                            Type="schema_failure",
+                            message="Experimental overlays cannot target global scope without explicit approval",
+                            phase_id="validate",
+                            evidence={"overlay_id": overlay.get("overlay_id")},
+                        ),
+                    )
+        if not args.experiment_scope.exists():
+            return _gate_failure(
+                failure_emitter,
+                args.run_id,
+                FailureLabel(
+                    Type="schema_failure",
+                    message="Experiment scope declaration missing",
+                    phase_id="validate",
+                    evidence={"path": str(args.experiment_scope)},
+                ),
+            )
+        exp_scope = json.loads(args.experiment_scope.read_text(encoding="utf-8"))
+        exp_errors = sorted(
+            Draft202012Validator(
+                json.loads((args.schema_dir / "experiment-scope.json").read_text(encoding="utf-8"))
+            ).iter_errors(exp_scope),
+            key=lambda e: e.path,
+        )
+        if exp_errors:
+            return _gate_failure(
+                failure_emitter,
+                args.run_id,
+                FailureLabel(
+                    Type="schema_failure",
+                    message="Experiment scope validation failed",
+                    phase_id="validate",
+                    evidence={
+                        "errors": [
+                            {
+                                "message": error.message,
+                                "path": list(error.path),
+                                "schema_path": list(error.schema_path),
+                            }
+                            for error in exp_errors
+                        ]
+                    },
+                ),
+            )
+        if not exp_scope.get("graduation_ready"):
+            return _gate_failure(
+                failure_emitter,
+                args.run_id,
+                FailureLabel(
+                    Type="schema_failure",
+                    message="Experiment scope exit criteria not met for graduation",
+                    phase_id="validate",
+                    evidence={"exp_id": exp_scope.get("exp_id")},
+                ),
+            )
+
+    if not args.eval_spec.exists():
+        return _gate_failure(
+            failure_emitter,
+            args.run_id,
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Evaluation spec is missing",
+                phase_id="validate",
+                evidence={"path": str(args.eval_spec)},
+            ),
+        )
+
+    eval_spec = json.loads(args.eval_spec.read_text(encoding="utf-8"))
+    eval_errors = validate_evaluation_spec(
+        eval_spec,
+        schema_dir=args.schema_dir,
+        spec_path=args.eval_spec,
+    )
+    if eval_errors:
+        return _gate_failure(
+            failure_emitter,
+            args.run_id,
+            FailureLabel(
+                Type="schema_failure",
+                message="Evaluation spec validation failed",
+                phase_id="validate",
+                evidence={"errors": eval_errors},
+            ),
+        )
+    rollback_artifact = eval_spec.get("rollback_plan", {}).get("artifact")
+    if rollback_artifact and not Path(rollback_artifact).exists():
+        return _gate_failure(
+            failure_emitter,
+            args.run_id,
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Evaluation rollback plan artifact is missing",
+                phase_id="validate",
+                evidence={"path": rollback_artifact},
+            ),
+        )
+
+    criteria = {metric["name"]: metric["threshold"] for metric in eval_spec.get("metrics", [])}
+    tolerance = float(eval_spec.get("regression_definition", {}).get("tolerance", 0.0))
+    checkpointer = EvaluationCheckpointer(success_criteria=criteria, tolerance=tolerance)
+    baseline_metrics = _load_metrics(args.eval_baseline)
+    candidate_metrics = _load_metrics(args.eval_candidate)
+    checkpointer.record("baseline", baseline_metrics)
+    candidate_checkpoint = checkpointer.record("candidate", candidate_metrics)
+    deltas = {
+        name: candidate_metrics.get(name, 0.0) - baseline_metrics.get(name, 0.0)
+        for name in set(baseline_metrics) | set(candidate_metrics)
+    }
+    override_used = False
+    if not candidate_checkpoint.passed and _has_breaking_override(overlays):
+        override_used = True
+
+    eval_report = {
+        "anchor": {
+            "anchor_id": "evaluation_report",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "scripts.run_promotion_readiness",
+            "status": "draft",
+        },
+        "run_id": args.run_id,
+        "eval_id": eval_spec.get("eval_id"),
+        "eval_version": eval_spec.get("eval_version"),
+        "baseline": baseline_metrics,
+        "candidate": candidate_metrics,
+        "deltas": deltas,
+        "passed": candidate_checkpoint.passed,
+        "regressions": candidate_checkpoint.regressions,
+        "rollback_recommended": candidate_checkpoint.rollback_recommended,
+        "override_used": override_used,
+        "inputs_hash": hash_data({"baseline": baseline_metrics, "candidate": candidate_metrics}),
+    }
+    eval_report_path = evidence_dir / "eval_report.json"
+    eval_report_path.write_text(json.dumps(eval_report, indent=2), encoding="utf-8")
+
+    interpret_notes = json.loads(args.eval_candidate.read_text(encoding="utf-8")).get(
+        "interpretive_notes", []
+    )
+    variance_payload = {
+        "anchor": {
+            "anchor_id": "interpret_variance_notes",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "scripts.run_promotion_readiness",
+            "status": "draft",
+        },
+        "run_id": args.run_id,
+        "notes": interpret_notes,
+    }
+    variance_path = evidence_dir / "interpret_variance_notes.json"
+    variance_path.write_text(json.dumps(variance_payload, indent=2), encoding="utf-8")
+
+    if not candidate_checkpoint.passed and not override_used:
+        return _gate_failure(
+            failure_emitter,
+            args.run_id,
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Evaluation checkpoint failed",
+                phase_id="validate",
+                evidence={"report": str(eval_report_path)},
+            ),
+        )
+
+    env_failure = check_environment_drift(args.lock_path)
+    if env_failure:
+        return _gate_failure(failure_emitter, args.run_id, env_failure)
+
+    env_report = {
+        "anchor": {
+            "anchor_id": "log_phase_report",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "scripts.run_promotion_readiness",
+            "status": "draft",
+        },
+        "run_id": args.run_id,
+        "inputs_hash": hash_data({"pdl": pdl_obj, "overlays": overlays}),
+        "phase_status": {
+            "schema_validation": "pass",
+            "phase_schema_validation": "pass",
+            "invariants_validation": "pass",
+            "reproducibility_validation": "pass",
+        },
+        "environment": environment_fingerprint(args.lock_path),
+    }
+    log_report_path = evidence_dir / "log_phase_report.json"
+    log_report_path.write_text(json.dumps(env_report, indent=2), encoding="utf-8")
+
+    compare_output_path = None
+    if "compare" in phase_outputs:
+        compare_output = {
+            "anchor": {
+                "anchor_id": "compare_output",
+                "anchor_version": "1.0.0",
+                "scope": "run",
+                "owner": "scripts.run_promotion_readiness",
+                "status": "draft",
+            },
+            "run_id": args.run_id,
+            "output": phase_outputs.get("compare"),
+        }
+        compare_output_path = evidence_dir / "compare_output.json"
+        compare_output_path.write_text(json.dumps(compare_output, indent=2), encoding="utf-8")
+
+    if args.release_track == "sswg-exp":
+        exp_summary = {
+            "anchor": {
+                "anchor_id": "experiment_summary",
+                "anchor_version": "1.0.0",
+                "scope": "run",
+                "owner": "scripts.run_promotion_readiness",
+                "status": "draft",
+            },
+            "run_id": args.run_id,
+            "eval_report": str(eval_report_path),
+            "provenance_manifest": str(evidence_dir / "provenance_manifest.json"),
+            "determinism_report": str(evidence_dir / "determinism_report.json"),
+            "notes": "sswg-exp run results pack generated.",
+        }
+        (evidence_dir / "experiment_summary.json").write_text(
+            json.dumps(exp_summary, indent=2),
+            encoding="utf-8",
+        )
+
+    artifact_paths = [
+        overlay_manifest_path,
+        overlay_report_path,
+        eval_report_path,
+        variance_path,
+        log_report_path,
+        evidence_dir / "determinism_report.json",
+        evidence_dir / "bijectivity_report.json",
+        evidence_dir / "phase_io_manifest.json",
+    ]
+    if compare_output_path:
+        artifact_paths.append(compare_output_path)
+
+    schema_refs = []
+    for schema_path in sorted(args.schema_dir.glob("*.json")):
+        schema_payload = json.loads(schema_path.read_text(encoding="utf-8"))
+        schema_refs.append(
+            {
+                "schema_id": schema_payload.get("$id", str(schema_path)),
+                "content_hash": hash_data(schema_payload),
+            }
+        )
+
+    phase_handlers = [
+        {"phase": phase.get("name"), "handler": phase.get("handler")}
+        for phase in pdl_obj.get("phases", [])
+    ]
+    provenance_manifest = {
+        "anchor": {
+            "anchor_id": "provenance_manifest",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "scripts.run_promotion_readiness",
+            "status": "draft",
+        },
+        "run_id": args.run_id,
+        "inputs_hash": hash_data({"pdl": pdl_obj, "overlays": overlays}),
+        "pdl_ref": str(args.pdl_path),
+        "schema_refs": schema_refs,
+        "overlay_chain": [
+            {
+                "overlay_id": overlay.get("overlay_id"),
+                "overlay_version": overlay.get("overlay_version"),
+            }
+            for overlay in overlays
+        ],
+        "phase_handlers": phase_handlers,
+        "artifacts": [_collect_artifact_entry(path) for path in artifact_paths],
+    }
+    provenance_path = evidence_dir / "provenance_manifest.json"
+    provenance_path.write_text(json.dumps(provenance_manifest, indent=2), encoding="utf-8")
+
+    provenance_target = Path("artifacts/provenance/provenance_manifest.json")
+    provenance_target.parent.mkdir(parents=True, exist_ok=True)
+    provenance_target.write_text(json.dumps(provenance_manifest, indent=2), encoding="utf-8")
+
+    for path in [
+        overlay_manifest_path,
+        overlay_report_path,
+        eval_report_path,
+        variance_path,
+        log_report_path,
+        provenance_path,
+    ]:
+        anchor_failure = enforce_anchor(
+            artifact_path=path,
+            metadata=json.loads(path.read_text(encoding="utf-8")).get("anchor", {}),
+            registry=registry,
+        )
+        if anchor_failure:
+            return _gate_failure(failure_emitter, args.run_id, anchor_failure)
+    if compare_output_path:
+        compare_anchor_failure = enforce_anchor(
+            artifact_path=compare_output_path,
+            metadata=json.loads(compare_output_path.read_text(encoding="utf-8")).get("anchor", {}),
+            registry=registry,
+        )
+        if compare_anchor_failure:
+            return _gate_failure(failure_emitter, args.run_id, compare_anchor_failure)
 
     try:
         validate_failure_label(

--- a/scripts/trace_provenance.py
+++ b/scripts/trace_provenance.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Trace provenance for a run or artifact.")
+    parser.add_argument(
+        "--provenance-path",
+        type=Path,
+        default=Path("artifacts/provenance/provenance_manifest.json"),
+        help="Provenance manifest path.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default=None,
+        help="Run identifier to trace.",
+    )
+    parser.add_argument(
+        "--artifact-id",
+        type=str,
+        default=None,
+        help="Artifact anchor_id or path to trace.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.provenance_path.exists():
+        print(f"Provenance manifest not found: {args.provenance_path}")
+        return 1
+
+    manifest = json.loads(args.provenance_path.read_text(encoding="utf-8"))
+    if args.run_id and manifest.get("run_id") != args.run_id:
+        print("Run id not found in provenance manifest")
+        return 1
+
+    artifact_focus = None
+    if args.artifact_id:
+        for artifact in manifest.get("artifacts", []):
+            anchor = artifact.get("anchor", {})
+            if anchor.get("anchor_id") == args.artifact_id or artifact.get("path") == args.artifact_id:
+                artifact_focus = artifact
+                break
+        if not artifact_focus:
+            print("Artifact id not found in provenance manifest")
+            return 1
+
+    lineage = {
+        "run_id": manifest.get("run_id"),
+        "inputs_hash": manifest.get("inputs_hash"),
+        "pdl_ref": manifest.get("pdl_ref"),
+        "schemas": manifest.get("schema_refs"),
+        "overlays": manifest.get("overlay_chain"),
+        "phase_handlers": manifest.get("phase_handlers"),
+        "artifact": artifact_focus,
+    }
+
+    print(json.dumps(lineage, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_evaluation_spec.py
+++ b/scripts/validate_evaluation_spec.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from generator.evaluation_spec import validate_evaluation_spec
+from generator.failure_emitter import FailureEmitter, FailureLabel
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate evaluation spec.")
+    parser.add_argument("spec_path", type=Path, help="Evaluation spec JSON path.")
+    parser.add_argument(
+        "--schema-dir",
+        type=Path,
+        default=Path("schemas"),
+        help="Schema directory.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default="local-run",
+        help="Run identifier for failure logs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.spec_path.exists():
+        failure = FailureLabel(
+            Type="reproducibility_failure",
+            message="Evaluation spec is missing",
+            phase_id="validate",
+            evidence={"path": str(args.spec_path)},
+        )
+        FailureEmitter(Path("artifacts/failures")).emit(failure, run_id=args.run_id)
+        print(f"Evaluation spec validation failed: {failure.as_dict()}")
+        return 1
+
+    spec = json.loads(args.spec_path.read_text(encoding="utf-8"))
+    errors = validate_evaluation_spec(spec, schema_dir=args.schema_dir, spec_path=args.spec_path)
+    if errors:
+        failure = FailureLabel(
+            Type="schema_failure",
+            message="Evaluation spec validation failed",
+            phase_id="validate",
+            evidence={"errors": errors},
+        )
+        FailureEmitter(Path("artifacts/failures")).emit(failure, run_id=args.run_id)
+        print(f"Evaluation spec validation failed: {failure.as_dict()}")
+        return 1
+
+    print(f"Evaluation spec validation passed: {args.spec_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_experiment_scope.py
+++ b/scripts/validate_experiment_scope.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator, RefResolver
+
+from generator.failure_emitter import FailureEmitter, FailureLabel
+
+
+def _get_validator(schema_dir: Path) -> Draft202012Validator:
+    schema = json.loads((schema_dir / "experiment-scope.json").read_text(encoding="utf-8"))
+    base_uri = schema_dir.as_uri().rstrip("/") + "/"
+    return Draft202012Validator(schema, resolver=RefResolver(base_uri=base_uri, referrer=schema))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate experiment scope declaration.")
+    parser.add_argument("scope_path", type=Path, help="Experiment scope JSON path.")
+    parser.add_argument(
+        "--schema-dir",
+        type=Path,
+        default=Path("schemas"),
+        help="Schema directory.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default="local-run",
+        help="Run identifier for failure logs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    if not args.scope_path.exists():
+        failure = FailureLabel(
+            Type="schema_failure",
+            message="Experiment scope declaration is missing",
+            phase_id="validate",
+            evidence={"path": str(args.scope_path)},
+        )
+        FailureEmitter(Path("artifacts/failures")).emit(failure, run_id=args.run_id)
+        print(f"Experiment scope validation failed: {failure.as_dict()}")
+        return 1
+
+    scope = json.loads(args.scope_path.read_text(encoding="utf-8"))
+    validator = _get_validator(args.schema_dir)
+    errors = sorted(validator.iter_errors(scope), key=lambda e: e.path)
+    if errors:
+        failure = FailureLabel(
+            Type="schema_failure",
+            message="Experiment scope validation failed",
+            phase_id="validate",
+            evidence={
+                "errors": [
+                    {
+                        "message": error.message,
+                        "path": list(error.path),
+                        "schema_path": list(error.schema_path),
+                    }
+                    for error in errors
+                ]
+            },
+        )
+        FailureEmitter(Path("artifacts/failures")).emit(failure, run_id=args.run_id)
+        print(f"Experiment scope validation failed: {failure.as_dict()}")
+        return 1
+
+    print(f"Experiment scope validation passed: {args.scope_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/eval_baseline.json
+++ b/tests/fixtures/eval_baseline.json
@@ -1,0 +1,8 @@
+{
+  "metrics": {
+    "overall_score": 0.62,
+    "clarity": 0.6,
+    "coverage": 0.59
+  },
+  "interpretive_notes": ["Baseline interpretive summary is stable."]
+}

--- a/tests/fixtures/eval_candidate.json
+++ b/tests/fixtures/eval_candidate.json
@@ -1,0 +1,8 @@
+{
+  "metrics": {
+    "overall_score": 0.63,
+    "clarity": 0.58,
+    "coverage": 0.6
+  },
+  "interpretive_notes": ["Candidate summary references measured artifacts."]
+}

--- a/tests/fixtures/overlay_descriptor.json
+++ b/tests/fixtures/overlay_descriptor.json
@@ -11,6 +11,8 @@
   ],
   "precedence": {
     "scope": "pdl",
+    "rules": "Explicit overlay precedence for PDL phase descriptions.",
+    "order": 10,
     "notes": "Overlay applies only to PDL phase descriptions."
   },
   "compatibility": {


### PR DESCRIPTION
### Motivation
- Prevent ambiguous or breaking overlays from being promoted without explicit governance and migration artifacts. 
- Ensure each iteration ships measurable evaluation artifacts and a rollback mechanism to block regressions. 
- Make every produced artifact traceable to inputs, schemas, overlays, handlers, and a reproducible run context. 
- Harden reproducibility by pinning runtime/dependencies and enforcing environment drift checks and experimental quarantine rules.

### Description
- Add overlay governance validation and ambiguity detection via `generator/overlay_governance.py` and `scripts/overlay_governance_validation.py`, and extend the `overlay-descriptor` schema to require precedence `rules`, `order`, and breaking-change migration/rollback artifacts. 
- Introduce an evaluation spec schema and validator in `schemas/evaluation-spec.json`, `generator/evaluation_spec.py`, plus a checkpoint runner `scripts/run_evaluation_checkpoint.py` and templates/fixtures under `docs/evaluation/` and `evaluations/`. 
- Emit provenance manifests and a read-only traceback tool via `schemas/provenance-manifest.json`, `scripts/trace_provenance.py`, and integrate provenance production into `scripts/run_promotion_readiness.py`. 
- Add environment lock schema and a generated dependency lock at `reproducibility/dependency_lock.json` with `generator/environment.py` plus drift check tooling `scripts/check_environment_drift.py` and a determinism replay gate `scripts/replay_determinism_gate.py`. 
- Enforce sswg-exp discipline by adding `schemas/experiment-scope.json`, experiment templates, and validations in `scripts/run_promotion_readiness.py` to block graduation unless `graduation_ready` is asserted and gating requirements pass. 
- Extend `scripts/run_promotion_readiness.py` to run overlay linting, ambiguity detection, evaluation checkpointing, environment drift checks, anchor enforcement, and to produce `overlay_promotion_report.json`, `eval_report.json`, `log_phase_report.json`, and `provenance_manifest.json` as promotion evidence.

### Testing
- No automated tests were executed as part of this change. 
- ✅ Local overlay governance check: `python scripts/overlay_governance_validation.py --overlays-dir overlays`. 
- ✅ Local evaluation checkpoint run: `python scripts/run_evaluation_checkpoint.py --eval-spec evaluations/eval_spec.json --baseline tests/fixtures/eval_baseline.json --candidate tests/fixtures/eval_candidate.json`. 
- ⚠️ CI should run the full promotion readiness gate via `python scripts/run_promotion_readiness.py` to produce evidence, enforce anchors, and verify deterministic-phase replay.
