### PR TITLE
Add secret redaction, agent policy, budgeting, docs, and audit gates with sanitizer and scanners

### DIFF
--- a/docs/artifact_glossary.json
+++ b/docs/artifact_glossary.json
@@ -1,0 +1,47 @@
+{
+  "anchor": {
+    "anchor_id": "artifact_glossary",
+    "anchor_version": "1.0.0",
+    "scope": "docs",
+    "owner": "documentation.glossary",
+    "status": "draft"
+  },
+  "artifact_map": [
+    {
+      "artifact_type": "run_telemetry",
+      "path": "artifacts/telemetry/run_telemetry.json",
+      "phase": "log",
+      "required_anchor": "run_telemetry"
+    },
+    {
+      "artifact_type": "provenance_manifest",
+      "path": "artifacts/provenance/provenance_manifest.json",
+      "phase": "log",
+      "required_anchor": "provenance_manifest"
+    },
+    {
+      "artifact_type": "budget_report",
+      "path": "artifacts/budgets/budget_report.json",
+      "phase": "validate",
+      "required_anchor": "budget_report"
+    },
+    {
+      "artifact_type": "policy_manifest",
+      "path": "artifacts/policy/policy_manifest.json",
+      "phase": "validate",
+      "required_anchor": "policy_manifest"
+    },
+    {
+      "artifact_type": "audit_bundle_manifest",
+      "path": "artifacts/audit/audit_bundle_manifest.json",
+      "phase": "log",
+      "required_anchor": "audit_bundle_manifest"
+    },
+    {
+      "artifact_type": "audit_certificate",
+      "path": "artifacts/audit/audit_certificate.json",
+      "phase": "log",
+      "required_anchor": "audit_certificate"
+    }
+  ]
+}

--- a/docs/onboarding_checklist.json
+++ b/docs/onboarding_checklist.json
@@ -1,0 +1,18 @@
+{
+  "anchor": {
+    "anchor_id": "onboarding_checklist",
+    "anchor_version": "1.0.0",
+    "scope": "docs",
+    "owner": "documentation.onboarding",
+    "status": "draft"
+  },
+  "checklist_id": "core_onboarding",
+  "checklist_version": "1.0.0",
+  "items": [
+    "Run PDL validation using generator.pdl_validator.",
+    "Confirm budget_validation gate passes with current telemetry.",
+    "Verify secrets_redaction_validation gate passes on artifacts/data/docs.",
+    "Review audit bundle manifest and certificate outputs.",
+    "Update artifact glossary and schema overlay map when outputs change."
+  ]
+}

--- a/docs/runbook.json
+++ b/docs/runbook.json
@@ -1,0 +1,28 @@
+{
+  "anchor": {
+    "anchor_id": "runbook",
+    "anchor_version": "1.0.0",
+    "scope": "docs",
+    "owner": "documentation.runbook",
+    "status": "draft"
+  },
+  "runbook_id": "core_operations",
+  "runbook_version": "1.0.0",
+  "steps": [
+    {
+      "title": "Validate PDL against schemas",
+      "command": "python -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas",
+      "expected_paths": ["artifacts/validation"]
+    },
+    {
+      "title": "Validate run telemetry artifact",
+      "command": "python scripts/validate_run_telemetry.py --telemetry-path artifacts/telemetry/run_telemetry.json",
+      "expected_paths": ["artifacts/telemetry/run_telemetry.json"]
+    }
+  ],
+  "promotion_notes": [
+    "Use overlay descriptors for any policy evolution.",
+    "Promotion checklists require deterministic phase replay evidence."
+  ],
+  "evolution_policy": "overlay_only"
+}

--- a/docs/schema_overlay_map.json
+++ b/docs/schema_overlay_map.json
@@ -1,0 +1,27 @@
+{
+  "anchor": {
+    "anchor_id": "schema_overlay_map",
+    "anchor_version": "1.0.0",
+    "scope": "docs",
+    "owner": "documentation.schemas",
+    "status": "draft"
+  },
+  "schema_refs": [
+    {
+      "schema_id": "https://schemas.sswg.local/pdl.json#",
+      "overlay_policy": "overlay_only",
+      "compatibility": "backward"
+    },
+    {
+      "schema_id": "https://schemas.sswg.local/run-telemetry.json#",
+      "overlay_policy": "overlay_only",
+      "compatibility": "backward"
+    },
+    {
+      "schema_id": "https://schemas.sswg.local/audit-bundle-spec.json#",
+      "overlay_policy": "overlay_only",
+      "compatibility": "backward"
+    }
+  ],
+  "notes": "Overlay descriptors must declare add/override/deprecate operations with compatibility statements."
+}

--- a/generator/agent_policy.py
+++ b/generator/agent_policy.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from generator.hashing import hash_data
+
+
+PROHIBITED_COMMANDS = (
+    "ls -R",
+    "grep -R",
+)
+
+
+@dataclass(frozen=True)
+class PolicyState:
+    repo_mode: str
+    agents_paths: list[str]
+    policy_hash: str
+
+
+def _hash_text(value: str) -> str:
+    payload = value.encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def list_agents_paths(repo_root: Path) -> list[Path]:
+    return sorted(repo_root.rglob("AGENTS.md"))
+
+
+def build_policy_hash(agents_paths: Iterable[Path]) -> str:
+    entries = []
+    for path in agents_paths:
+        entries.append(
+            {
+                "path": str(path),
+                "content_hash": _hash_text(path.read_text(encoding="utf-8")),
+            }
+        )
+    return hash_data(entries)
+
+
+def parse_command(command: str) -> list[str]:
+    return [part for part in command.strip().split() if part]
+
+
+def is_prohibited_command(command: str) -> bool:
+    parts = parse_command(command)
+    if not parts:
+        return False
+    executable = parts[0]
+    args = parts[1:]
+    if executable in {"ls", "grep"} and "-R" in args:
+        return True
+    return False
+
+
+def find_prohibited_commands(commands: Iterable[str]) -> list[str]:
+    return [command for command in commands if is_prohibited_command(command)]
+
+
+def detect_working_tree_changes(repo_root: Path) -> list[str]:
+    result = subprocess.run(
+        ["git", "status", "--porcelain"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout.strip()
+    if not output:
+        return []
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def build_policy_manifest(
+    policy: PolicyState,
+    *,
+    effective_scope: Path,
+    prohibited_commands: Iterable[str] = PROHIBITED_COMMANDS,
+) -> dict:
+    return {
+        "anchor": {
+            "anchor_id": "policy_manifest",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "generator.agent_policy",
+            "status": "draft",
+        },
+        "effective_agents_scope": str(effective_scope),
+        "policy_hash": policy.policy_hash,
+        "prohibited_commands": list(prohibited_commands),
+        "repo_mode": policy.repo_mode,
+        "agents_paths": policy.agents_paths,
+    }
+
+
+def policy_state(repo_root: Path, repo_mode: str) -> PolicyState:
+    agents_paths = list_agents_paths(repo_root)
+    return PolicyState(
+        repo_mode=repo_mode,
+        agents_paths=[str(path) for path in agents_paths],
+        policy_hash=build_policy_hash(agents_paths),
+    )
+
+
+def read_commands_from_file(commands_file: Optional[Path]) -> list[str]:
+    if commands_file is None or not commands_file.exists():
+        return []
+    return [
+        line.strip()
+        for line in commands_file.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]

--- a/generator/audit_bundle.py
+++ b/generator/audit_bundle.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from generator.hashing import hash_data
+
+
+@dataclass(frozen=True)
+class BundleEntry:
+    component_id: str
+    source_path: Path
+    bundle_path: Path
+    content_hash: str
+
+
+def load_audit_spec(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _hash_file(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _resolve_components(spec: Dict[str, Any], run_id: str) -> List[dict]:
+    components = []
+    for component in spec.get("components", []):
+        if "path_template" in component:
+            path = component["path_template"].format(run_id=run_id)
+            components.append({"component_id": component["component_id"], "paths": [path]})
+        elif "path_glob" in component:
+            paths = sorted(Path(".").glob(component["path_glob"]))
+            components.append(
+                {
+                    "component_id": component["component_id"],
+                    "paths": [str(path) for path in paths],
+                }
+            )
+    return components
+
+
+def build_bundle(
+    *,
+    spec: Dict[str, Any],
+    run_id: str,
+    bundle_dir: Path,
+    manifest_path: Path,
+) -> Dict[str, Any]:
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    entries: List[BundleEntry] = []
+
+    for component in _resolve_components(spec, run_id):
+        component_id = component["component_id"]
+        for source in component.get("paths", []):
+            source_path = Path(source)
+            if not source_path.exists():
+                continue
+            target_dir = bundle_dir / component_id
+            target_dir.mkdir(parents=True, exist_ok=True)
+            target_path = target_dir / source_path.name
+            shutil.copy2(source_path, target_path)
+            entries.append(
+                BundleEntry(
+                    component_id=component_id,
+                    source_path=source_path,
+                    bundle_path=target_path,
+                    content_hash=_hash_file(target_path),
+                )
+            )
+
+    manifest = {
+        "anchor": {
+            "anchor_id": "audit_bundle_manifest",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "generator.audit_bundle",
+            "status": "draft",
+        },
+        "run_id": run_id,
+        "bundle_dir": str(bundle_dir),
+        "entries": [
+            {
+                "component_id": entry.component_id,
+                "source_path": str(entry.source_path),
+                "bundle_path": str(entry.bundle_path),
+                "content_hash": entry.content_hash,
+            }
+            for entry in entries
+        ],
+    }
+    manifest["bundle_hash"] = hash_data(manifest["entries"])
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest
+
+
+def validate_bundle(manifest: Dict[str, Any]) -> Dict[str, Any]:
+    errors = []
+    entries = manifest.get("entries", [])
+    run_id = manifest.get("run_id")
+    overlay_chain = None
+    inputs_hash = None
+
+    for entry in entries:
+        bundle_path = Path(entry.get("bundle_path", ""))
+        if not bundle_path.exists():
+            errors.append({"type": "missing_bundle_path", "path": str(bundle_path)})
+            continue
+        content_hash = _hash_file(bundle_path)
+        if content_hash != entry.get("content_hash"):
+            errors.append({"type": "hash_mismatch", "path": str(bundle_path)})
+        if bundle_path.suffix == ".json":
+            try:
+                payload = json.loads(bundle_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                continue
+            if run_id and payload.get("run_id") not in (None, run_id):
+                errors.append(
+                    {
+                        "type": "run_id_mismatch",
+                        "path": str(bundle_path),
+                        "value": payload.get("run_id"),
+                    }
+                )
+            if "overlay_chain" in payload:
+                if overlay_chain is None:
+                    overlay_chain = payload.get("overlay_chain")
+                elif overlay_chain != payload.get("overlay_chain"):
+                    errors.append(
+                        {
+                            "type": "overlay_chain_mismatch",
+                            "path": str(bundle_path),
+                        }
+                    )
+            if "inputs_hash" in payload:
+                if inputs_hash is None:
+                    inputs_hash = payload.get("inputs_hash")
+                elif inputs_hash != payload.get("inputs_hash"):
+                    errors.append(
+                        {
+                            "type": "inputs_hash_mismatch",
+                            "path": str(bundle_path),
+                        }
+                    )
+
+    status = "pass" if not errors else "fail"
+    return {"status": status, "errors": errors}

--- a/generator/budgeting.py
+++ b/generator/budgeting.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+from generator.hashing import hash_data
+
+
+def load_budget_spec(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _size_bytes(path: Path) -> int | None:
+    if not path.exists():
+        return None
+    return path.stat().st_size
+
+
+def collect_artifact_sizes(artifact_budgets: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    results: List[Dict[str, Any]] = []
+    for budget in artifact_budgets:
+        paths = [Path(path) for path in budget.get("paths", [])]
+        sizes = []
+        missing = []
+        for path in paths:
+            size = _size_bytes(path)
+            if size is None:
+                missing.append(str(path))
+            else:
+                sizes.append(size)
+        results.append(
+            {
+                "artifact_class": budget.get("artifact_class"),
+                "paths": [str(path) for path in paths],
+                "size_bytes": sum(sizes),
+                "missing": missing,
+                "max_size_mb": budget.get("max_size_mb"),
+            }
+        )
+    return results
+
+
+def evaluate_budgets(
+    *,
+    budget_spec: Dict[str, Any],
+    phase_durations: Dict[str, float],
+    artifact_sizes: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    phase_results = []
+    for phase, limits in budget_spec.get("phase_budgets", {}).items():
+        max_duration = float(limits.get("max_duration_sec", 0))
+        observed = float(phase_durations.get(phase, 0))
+        phase_results.append(
+            {
+                "phase": phase,
+                "max_duration_sec": max_duration,
+                "observed_duration_sec": observed,
+                "pass": observed <= max_duration,
+            }
+        )
+
+    artifact_results = []
+    for entry in artifact_sizes:
+        max_size_mb = float(entry.get("max_size_mb") or 0)
+        size_bytes = float(entry.get("size_bytes") or 0)
+        max_size_bytes = max_size_mb * 1024 * 1024
+        artifact_results.append(
+            {
+                "artifact_class": entry.get("artifact_class"),
+                "paths": entry.get("paths", []),
+                "size_bytes": size_bytes,
+                "max_size_bytes": max_size_bytes,
+                "missing": entry.get("missing", []),
+                "pass": bool(entry.get("missing") == [] and size_bytes <= max_size_bytes),
+            }
+        )
+
+    total_duration = sum(float(duration) for duration in phase_durations.values())
+    max_total = float(budget_spec.get("max_total_duration_sec", 0))
+    total_pass = total_duration <= max_total
+
+    violations = []
+    for result in phase_results:
+        if not result["pass"]:
+            violations.append({"type": "phase_duration", "phase": result["phase"]})
+    for result in artifact_results:
+        if not result["pass"]:
+            violations.append({"type": "artifact_size", "artifact_class": result["artifact_class"]})
+    if not total_pass:
+        violations.append({"type": "total_duration"})
+
+    status = "pass" if not violations else "fail"
+    report = {
+        "status": status,
+        "phase_results": phase_results,
+        "artifact_results": artifact_results,
+        "total_duration_sec": total_duration,
+        "max_total_duration_sec": max_total,
+        "violations": violations,
+    }
+    report["inputs_hash"] = hash_data(report)
+    return report

--- a/generator/sanitizer.py
+++ b/generator/sanitizer.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import math
+import re
+from typing import Any, Iterable, Mapping
+
+SENSITIVE_KEYS = (
+    "password",
+    "secret",
+    "token",
+    "api_key",
+    "credential",
+    "private_key",
+)
+
+SECRET_PATTERNS = [
+    re.compile(r"-----BEGIN (?:RSA|DSA|EC|OPENSSH|PGP)? PRIVATE KEY-----"),
+    re.compile(r"sk-[A-Za-z0-9]{16,}"),
+    re.compile(r"AKIA[0-9A-Z]{16}"),
+    re.compile(r"(?i)aws_secret_access_key\s*[:=]"),
+    re.compile(r"(?i)api[_-]?key\s*[:=]"),
+    re.compile(r"(?i)token\s*[:=]"),
+    re.compile(r"(?i)password\s*[:=]"),
+    re.compile(r"(?i)secret\s*[:=]"),
+]
+
+HIGH_ENTROPY_PATTERN = re.compile(r"[A-Za-z0-9+/=_-]{20,}")
+
+MAX_STRING_LENGTH = 256
+HIGH_ENTROPY_THRESHOLD = 4.0
+
+
+def shannon_entropy(value: str) -> float:
+    if not value:
+        return 0.0
+    counts = {}
+    for char in value:
+        counts[char] = counts.get(char, 0) + 1
+    length = len(value)
+    return -sum((count / length) * math.log2(count / length) for count in counts.values())
+
+
+def _truncate(value: str) -> str:
+    if len(value) <= MAX_STRING_LENGTH:
+        return value
+    return value[:MAX_STRING_LENGTH] + "...[TRUNCATED]"
+
+
+def redact_text(value: str) -> str:
+    redacted = value
+    for pattern in SECRET_PATTERNS:
+        redacted = pattern.sub("[REDACTED]", redacted)
+    for token in HIGH_ENTROPY_PATTERN.findall(redacted):
+        if shannon_entropy(token) >= HIGH_ENTROPY_THRESHOLD:
+            redacted = redacted.replace(token, "[REDACTED]")
+    return _truncate(redacted)
+
+
+def find_secret_indicators(value: str) -> list[str]:
+    indicators: list[str] = []
+    for pattern in SECRET_PATTERNS:
+        if pattern.search(value):
+            indicators.append(pattern.pattern)
+    for token in HIGH_ENTROPY_PATTERN.findall(value):
+        if shannon_entropy(token) >= HIGH_ENTROPY_THRESHOLD:
+            indicators.append("high_entropy")
+            break
+    return indicators
+
+
+def _sanitize_mapping(data: Mapping[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {}
+    for key, value in data.items():
+        key_lower = key.lower()
+        if any(token in key_lower for token in SENSITIVE_KEYS):
+            sanitized[key] = "[REDACTED]"
+        else:
+            sanitized[key] = sanitize_payload(value)
+    return sanitized
+
+
+def _sanitize_iterable(values: Iterable[Any]) -> list[Any]:
+    return [sanitize_payload(value) for value in values]
+
+
+def sanitize_payload(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return _sanitize_mapping(value)
+    if isinstance(value, (list, tuple)):
+        return _sanitize_iterable(value)
+    if isinstance(value, str):
+        return redact_text(value)
+    return value

--- a/generator/secret_scanner.py
+++ b/generator/secret_scanner.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import fnmatch
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from generator.sanitizer import find_secret_indicators
+
+
+CANONICAL_DIRS = ("generator", "cli", "pdl", "reproducibility")
+
+
+@dataclass(frozen=True)
+class AllowlistEntry:
+    entry_id: str
+    path_glob: str
+    pattern: str
+    scope: str
+    expires_at: str
+    approved_by: str
+    approval_ref: str
+    allow_on_canonical: bool
+
+
+def _parse_allowlist(path: Path) -> list[AllowlistEntry]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    entries = []
+    for raw in payload.get("entries", []):
+        entries.append(
+            AllowlistEntry(
+                entry_id=raw.get("entry_id", ""),
+                path_glob=raw.get("path_glob", ""),
+                pattern=raw.get("pattern", ""),
+                scope=raw.get("scope", ""),
+                expires_at=raw.get("expires_at", ""),
+                approved_by=raw.get("approved_by", ""),
+                approval_ref=raw.get("approval_ref", ""),
+                allow_on_canonical=bool(raw.get("allow_on_canonical", False)),
+            )
+        )
+    return entries
+
+
+def _is_expired(timestamp: str) -> bool:
+    try:
+        expires = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    return expires <= datetime.now(timezone.utc)
+
+
+def load_allowlist(path: Optional[Path]) -> list[AllowlistEntry]:
+    if path is None or not path.exists():
+        return []
+    return _parse_allowlist(path)
+
+
+def _matches_entry(entry: AllowlistEntry, path: Path, indicators: Iterable[str]) -> bool:
+    if not fnmatch.fnmatch(str(path), entry.path_glob):
+        return False
+    if entry.pattern and entry.pattern not in indicators:
+        return False
+    return True
+
+
+def _is_canonical_path(path: Path) -> bool:
+    parts = path.parts
+    return len(parts) > 0 and parts[0] in CANONICAL_DIRS
+
+
+def _scan_text(content: str) -> list[str]:
+    indicators = set()
+    for line in content.splitlines():
+        indicators.update(find_secret_indicators(line))
+    return sorted(indicators)
+
+
+def scan_file(path: Path) -> list[str]:
+    if path.name.endswith(".env"):
+        return ["env_file"]
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return []
+    return _scan_text(content)
+
+
+def scan_paths(
+    paths: Iterable[Path],
+    *,
+    allowlist: list[AllowlistEntry],
+) -> dict:
+    violations = []
+    allowlist_errors = []
+    for entry in allowlist:
+        if not entry.entry_id or not entry.path_glob:
+            allowlist_errors.append({"entry_id": entry.entry_id, "reason": "missing required fields"})
+            continue
+        if not entry.approved_by or not entry.approval_ref:
+            allowlist_errors.append({"entry_id": entry.entry_id, "reason": "missing approval metadata"})
+            continue
+        if _is_expired(entry.expires_at):
+            allowlist_errors.append({"entry_id": entry.entry_id, "reason": "allowlist entry expired"})
+            continue
+        if entry.allow_on_canonical:
+            allowlist_errors.append({"entry_id": entry.entry_id, "reason": "allowlist cannot apply to canonical"})
+            continue
+
+    for path in paths:
+        if not path.exists():
+            continue
+        if path.is_dir():
+            for file_path in path.rglob("*"):
+                if file_path.is_dir():
+                    continue
+                violations.extend(_scan_single_path(file_path, allowlist, allowlist_errors))
+        else:
+            violations.extend(_scan_single_path(path, allowlist, allowlist_errors))
+
+    return {"violations": violations, "allowlist_errors": allowlist_errors}
+
+
+def _scan_single_path(
+    path: Path,
+    allowlist: list[AllowlistEntry],
+    allowlist_errors: list[dict],
+) -> list[dict]:
+    indicators = scan_file(path)
+    if not indicators:
+        return []
+    if _is_canonical_path(path):
+        allowlist_errors.append(
+            {
+                "entry_id": None,
+                "reason": "canonical paths cannot be allowlisted",
+                "path": str(path),
+            }
+        )
+        return [
+            {
+                "path": str(path),
+                "indicators": indicators,
+                "allowlisted": False,
+            }
+        ]
+    for entry in allowlist:
+        if _matches_entry(entry, path, indicators):
+            return []
+    return [
+        {
+            "path": str(path),
+            "indicators": indicators,
+            "allowlisted": False,
+        }
+    ]

--- a/governance/audit_bundle_spec.json
+++ b/governance/audit_bundle_spec.json
@@ -1,0 +1,54 @@
+{
+  "anchor": {
+    "anchor_id": "audit_bundle_spec",
+    "anchor_version": "1.0.0",
+    "scope": "governance",
+    "owner": "audit.compliance",
+    "status": "draft"
+  },
+  "spec_id": "audit_bundle_v1",
+  "spec_version": "1.0.0",
+  "components": [
+    {
+      "component_id": "pdl",
+      "path_template": "pdl/example_full_9_phase.yaml"
+    },
+    {
+      "component_id": "schemas",
+      "path_glob": "schemas/*.json"
+    },
+    {
+      "component_id": "overlay_chain_manifest",
+      "path_template": "artifacts/evidence_pack/{run_id}/overlay_chain_manifest.json"
+    },
+    {
+      "component_id": "provenance_manifest",
+      "path_template": "artifacts/evidence_pack/{run_id}/provenance_manifest.json"
+    },
+    {
+      "component_id": "evaluation_report",
+      "path_template": "artifacts/evidence_pack/{run_id}/eval_report.json"
+    },
+    {
+      "component_id": "determinism_report",
+      "path_template": "artifacts/evidence_pack/{run_id}/determinism_report.json"
+    },
+    {
+      "component_id": "log_phase_report",
+      "path_template": "artifacts/evidence_pack/{run_id}/log_phase_report.json"
+    },
+    {
+      "component_id": "run_telemetry",
+      "path_template": "artifacts/telemetry/run_telemetry.json"
+    },
+    {
+      "component_id": "budget_report",
+      "path_template": "artifacts/budgets/budget_report.json"
+    },
+    {
+      "component_id": "policy_manifest",
+      "path_template": "artifacts/policy/policy_manifest.json"
+    }
+  ],
+  "evolution_policy": "overlay_only"
+}

--- a/governance/budget_spec.json
+++ b/governance/budget_spec.json
@@ -1,0 +1,36 @@
+{
+  "anchor": {
+    "anchor_id": "budget_spec",
+    "anchor_version": "1.0.0",
+    "scope": "governance",
+    "owner": "performance.budgets",
+    "status": "draft"
+  },
+  "budget_id": "phase_budget_v1",
+  "budget_version": "1.0.0",
+  "phase_budgets": {
+    "ingest": { "max_duration_sec": 300 },
+    "normalize": { "max_duration_sec": 300 },
+    "parse": { "max_duration_sec": 300 },
+    "analyze": { "max_duration_sec": 300 },
+    "generate": { "max_duration_sec": 300 },
+    "validate": { "max_duration_sec": 300 },
+    "compare": { "max_duration_sec": 300 },
+    "interpret": { "max_duration_sec": 300 },
+    "log": { "max_duration_sec": 300 }
+  },
+  "artifact_budgets": [
+    {
+      "artifact_class": "telemetry",
+      "paths": ["artifacts/telemetry/run_telemetry.json"],
+      "max_size_mb": 5
+    },
+    {
+      "artifact_class": "provenance",
+      "paths": ["artifacts/provenance/provenance_manifest.json"],
+      "max_size_mb": 5
+    }
+  ],
+  "max_total_duration_sec": 1800,
+  "evolution_policy": "overlay_only"
+}

--- a/governance/secret_allowlist.json
+++ b/governance/secret_allowlist.json
@@ -1,0 +1,12 @@
+{
+  "anchor": {
+    "anchor_id": "secret_allowlist",
+    "anchor_version": "1.0.0",
+    "scope": "governance",
+    "owner": "security.allowlist",
+    "status": "draft"
+  },
+  "allowlist_id": "secret_exceptions",
+  "allowlist_version": "1.0.0",
+  "entries": []
+}

--- a/governance/secret_redaction_policy.json
+++ b/governance/secret_redaction_policy.json
@@ -1,0 +1,30 @@
+{
+  "anchor": {
+    "anchor_id": "secret_redaction_policy",
+    "anchor_version": "1.0.0",
+    "scope": "governance",
+    "owner": "security.redaction",
+    "status": "draft"
+  },
+  "policy_id": "zero_leak_canon",
+  "policy_version": "1.0.0",
+  "forbidden_classes": [
+    "api_keys",
+    "tokens",
+    "private_keys",
+    "env_secrets",
+    "high_entropy"
+  ],
+  "allowed_transformations": [
+    "replace_with_redacted",
+    "truncate_payload",
+    "drop_sensitive_fields"
+  ],
+  "escalation": {
+    "owner_team": "security",
+    "review_required": true,
+    "contact": "security@sswg.local"
+  },
+  "allowlist_ref": "governance/secret_allowlist.json",
+  "evolution_policy": "overlay_only"
+}

--- a/schemas/audit-bundle-manifest.json
+++ b/schemas/audit-bundle-manifest.json
@@ -1,0 +1,39 @@
+{
+  "$id": "https://schemas.sswg.local/audit-bundle-manifest.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg audit bundle manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["anchor", "run_id", "bundle_dir", "entries", "bundle_hash"],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "sandbox", "canonical", "archived"] }
+      }
+    },
+    "run_id": { "type": "string" },
+    "bundle_dir": { "type": "string" },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["component_id", "source_path", "bundle_path", "content_hash"],
+        "properties": {
+          "component_id": { "type": "string" },
+          "source_path": { "type": "string" },
+          "bundle_path": { "type": "string" },
+          "content_hash": { "type": "string" }
+        }
+      }
+    },
+    "bundle_hash": { "type": "string" }
+  }
+}

--- a/schemas/audit-bundle-spec.json
+++ b/schemas/audit-bundle-spec.json
@@ -1,0 +1,42 @@
+{
+  "$id": "https://schemas.sswg.local/audit-bundle-spec.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg audit bundle spec",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["anchor", "spec_id", "spec_version", "components", "evolution_policy"],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "sandbox", "canonical", "archived"] }
+      }
+    },
+    "spec_id": { "type": "string" },
+    "spec_version": { "type": "string" },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["component_id"],
+        "properties": {
+          "component_id": { "type": "string" },
+          "path_template": { "type": "string" },
+          "path_glob": { "type": "string" }
+        },
+        "oneOf": [
+          { "required": ["path_template"] },
+          { "required": ["path_glob"] }
+        ]
+      }
+    },
+    "evolution_policy": { "type": "string" }
+  }
+}

--- a/schemas/audit-certificate.json
+++ b/schemas/audit-certificate.json
@@ -1,0 +1,26 @@
+{
+  "$id": "https://schemas.sswg.local/audit-certificate.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg audit certificate",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["anchor", "run_id", "bundle_hash", "coverage", "gating_summary"],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "sandbox", "canonical", "archived"] }
+      }
+    },
+    "run_id": { "type": "string" },
+    "bundle_hash": { "type": "string" },
+    "coverage": { "type": "object" },
+    "gating_summary": { "type": "object" }
+  }
+}

--- a/schemas/budget-report.json
+++ b/schemas/budget-report.json
@@ -1,0 +1,40 @@
+{
+  "$id": "https://schemas.sswg.local/budget-report.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg budget report",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "anchor",
+    "run_id",
+    "status",
+    "phase_results",
+    "artifact_results",
+    "total_duration_sec",
+    "max_total_duration_sec",
+    "violations",
+    "inputs_hash"
+  ],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "sandbox", "canonical", "archived"] }
+      }
+    },
+    "run_id": { "type": "string" },
+    "status": { "type": "string", "enum": ["pass", "fail"] },
+    "phase_results": { "type": "array" },
+    "artifact_results": { "type": "array" },
+    "total_duration_sec": { "type": "number", "minimum": 0 },
+    "max_total_duration_sec": { "type": "number", "minimum": 0 },
+    "violations": { "type": "array" },
+    "inputs_hash": { "type": "string" }
+  }
+}

--- a/schemas/budget-spec.json
+++ b/schemas/budget-spec.json
@@ -1,0 +1,58 @@
+{
+  "$id": "https://schemas.sswg.local/budget-spec.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg budget specification",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "anchor",
+    "budget_id",
+    "budget_version",
+    "phase_budgets",
+    "artifact_budgets",
+    "max_total_duration_sec",
+    "evolution_policy"
+  ],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "sandbox", "canonical", "archived"] }
+      }
+    },
+    "budget_id": { "type": "string" },
+    "budget_version": { "type": "string" },
+    "phase_budgets": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["max_duration_sec"],
+        "properties": {
+          "max_duration_sec": { "type": "number", "minimum": 0 }
+        }
+      }
+    },
+    "artifact_budgets": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["artifact_class", "paths", "max_size_mb"],
+        "properties": {
+          "artifact_class": { "type": "string" },
+          "paths": { "type": "array", "items": { "type": "string" } },
+          "max_size_mb": { "type": "number", "minimum": 0 }
+        }
+      }
+    },
+    "max_total_duration_sec": { "type": "number", "minimum": 0 },
+    "evolution_policy": { "type": "string" }
+  }
+}

--- a/schemas/policy-manifest.json
+++ b/schemas/policy-manifest.json
@@ -1,0 +1,34 @@
+{
+  "$id": "https://schemas.sswg.local/policy-manifest.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg policy manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "anchor",
+    "effective_agents_scope",
+    "policy_hash",
+    "prohibited_commands",
+    "repo_mode",
+    "agents_paths"
+  ],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "sandbox", "canonical", "archived"] }
+      }
+    },
+    "effective_agents_scope": { "type": "string" },
+    "policy_hash": { "type": "string" },
+    "prohibited_commands": { "type": "array", "items": { "type": "string" } },
+    "repo_mode": { "type": "string" },
+    "agents_paths": { "type": "array", "items": { "type": "string" } }
+  }
+}

--- a/schemas/run-telemetry.json
+++ b/schemas/run-telemetry.json
@@ -8,6 +8,8 @@
     "anchor",
     "run_id",
     "phase_durations",
+    "artifact_sizes",
+    "budget_status",
     "gate_results",
     "failure_counts",
     "determinism_status",
@@ -32,6 +34,38 @@
     "phase_durations": {
       "type": "object",
       "additionalProperties": { "type": "number", "minimum": 0 }
+    },
+    "artifact_sizes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["artifact_class", "paths", "size_bytes", "max_size_bytes", "pass"],
+        "properties": {
+          "artifact_class": { "type": "string" },
+          "paths": { "type": "array", "items": { "type": "string" } },
+          "size_bytes": { "type": "number", "minimum": 0 },
+          "max_size_bytes": { "type": "number", "minimum": 0 },
+          "pass": { "type": "boolean" }
+        }
+      }
+    },
+    "budget_status": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status", "phase_budgets", "artifact_budgets", "total_budget"],
+      "properties": {
+        "status": { "type": "string", "enum": ["pass", "fail"] },
+        "phase_budgets": {
+          "type": "object",
+          "additionalProperties": { "type": "string", "enum": ["pass", "fail"] }
+        },
+        "artifact_budgets": {
+          "type": "object",
+          "additionalProperties": { "type": "string", "enum": ["pass", "fail"] }
+        },
+        "total_budget": { "type": "string", "enum": ["pass", "fail"] }
+      }
     },
     "gate_results": {
       "type": "object",

--- a/schemas/secret-allowlist.json
+++ b/schemas/secret-allowlist.json
@@ -1,0 +1,51 @@
+{
+  "$id": "https://schemas.sswg.local/secret-allowlist.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg secret allowlist",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["anchor", "allowlist_id", "allowlist_version", "entries"],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "sandbox", "canonical", "archived"] }
+      }
+    },
+    "allowlist_id": { "type": "string" },
+    "allowlist_version": { "type": "string" },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "entry_id",
+          "path_glob",
+          "pattern",
+          "scope",
+          "expires_at",
+          "approved_by",
+          "approval_ref",
+          "allow_on_canonical"
+        ],
+        "properties": {
+          "entry_id": { "type": "string" },
+          "path_glob": { "type": "string" },
+          "pattern": { "type": "string" },
+          "scope": { "type": "string" },
+          "expires_at": { "type": "string" },
+          "approved_by": { "type": "string" },
+          "approval_ref": { "type": "string" },
+          "allow_on_canonical": { "type": "boolean" }
+        }
+      }
+    }
+  }
+}

--- a/schemas/secret-redaction-policy.json
+++ b/schemas/secret-redaction-policy.json
@@ -1,0 +1,47 @@
+{
+  "$id": "https://schemas.sswg.local/secret-redaction-policy.json#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "sswg secret redaction policy",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "anchor",
+    "policy_id",
+    "policy_version",
+    "forbidden_classes",
+    "allowed_transformations",
+    "escalation",
+    "allowlist_ref",
+    "evolution_policy"
+  ],
+  "properties": {
+    "anchor": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["anchor_id", "anchor_version", "scope", "owner", "status"],
+      "properties": {
+        "anchor_id": { "type": "string" },
+        "anchor_version": { "type": "string" },
+        "scope": { "type": "string" },
+        "owner": { "type": "string" },
+        "status": { "type": "string", "enum": ["draft", "sandbox", "canonical", "archived"] }
+      }
+    },
+    "policy_id": { "type": "string" },
+    "policy_version": { "type": "string" },
+    "forbidden_classes": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "allowed_transformations": { "type": "array", "minItems": 1, "items": { "type": "string" } },
+    "escalation": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["owner_team", "review_required", "contact"],
+      "properties": {
+        "owner_team": { "type": "string" },
+        "review_required": { "type": "boolean" },
+        "contact": { "type": "string" }
+      }
+    },
+    "allowlist_ref": { "type": "string" },
+    "evolution_policy": { "type": "string" }
+  }
+}

--- a/scripts/agents_policy_validation.py
+++ b/scripts/agents_policy_validation.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from generator.agent_policy import (
+    build_policy_manifest,
+    detect_working_tree_changes,
+    find_prohibited_commands,
+    list_agents_paths,
+    policy_state,
+    read_commands_from_file,
+)
+from generator.failure_emitter import FailureEmitter, FailureLabel
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate AGENTS.md policy compliance.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path("."),
+        help="Repository root containing AGENTS.md.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default="policy-validate",
+        help="Run identifier.",
+    )
+    parser.add_argument(
+        "--mode",
+        type=str,
+        choices=["qa-readonly", "edit-permitted"],
+        default="edit-permitted",
+        help="Repository mode for write enforcement.",
+    )
+    parser.add_argument(
+        "--commands-file",
+        type=Path,
+        help="Optional file containing executed commands to validate.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    emitter = FailureEmitter(Path("artifacts/policy/failures"))
+    repo_root = args.repo_root
+    root_agents = repo_root / "AGENTS.md"
+
+    if not root_agents.exists():
+        emitter.emit(
+            FailureLabel(
+                Type="tool_mismatch",
+                message="Root AGENTS.md missing from repository",
+                phase_id="validate",
+                evidence={"path": str(root_agents)},
+            ),
+            run_id=args.run_id,
+        )
+        print("Agents policy validation failed")
+        return 1
+
+    agents_paths = list_agents_paths(repo_root)
+    if not agents_paths:
+        emitter.emit(
+            FailureLabel(
+                Type="tool_mismatch",
+                message="No AGENTS.md files found in repository scope",
+                phase_id="validate",
+                evidence={"path": str(repo_root)},
+            ),
+            run_id=args.run_id,
+        )
+        print("Agents policy validation failed")
+        return 1
+
+    commands = read_commands_from_file(args.commands_file)
+    prohibited = find_prohibited_commands(commands)
+    if prohibited:
+        emitter.emit(
+            FailureLabel(
+                Type="tool_mismatch",
+                message="Prohibited commands detected in agent execution",
+                phase_id="validate",
+                evidence={"commands": prohibited},
+            ),
+            run_id=args.run_id,
+        )
+        print("Agents policy validation failed")
+        return 1
+
+    if args.mode == "qa-readonly":
+        changes = detect_working_tree_changes(repo_root)
+        if changes:
+            emitter.emit(
+                FailureLabel(
+                    Type="tool_mismatch",
+                    message="QA mode forbids working tree modifications",
+                    phase_id="validate",
+                    evidence={"changes": changes},
+                ),
+                run_id=args.run_id,
+            )
+            print("Agents policy validation failed")
+            return 1
+
+    state = policy_state(repo_root, args.mode)
+    manifest = build_policy_manifest(state, effective_scope=root_agents)
+    manifest_path = Path("artifacts/policy/policy_manifest.json")
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+
+    print("Agents policy validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_bundle_builder.py
+++ b/scripts/audit_bundle_builder.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import argparse
+
+from pathlib import Path
+
+from generator.audit_bundle import build_bundle, load_audit_spec
+from generator.failure_emitter import FailureEmitter, FailureLabel
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build audit evidence bundle.")
+    parser.add_argument(
+        "--audit-spec",
+        type=Path,
+        default=Path("governance/audit_bundle_spec.json"),
+        help="Audit bundle specification path.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default="audit-run",
+        help="Run identifier.",
+    )
+    parser.add_argument(
+        "--bundle-dir",
+        type=Path,
+        default=Path("artifacts/audit"),
+        help="Audit bundle directory.",
+    )
+    parser.add_argument(
+        "--manifest-path",
+        type=Path,
+        default=Path("artifacts/audit/audit_bundle_manifest.json"),
+        help="Audit bundle manifest path.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    emitter = FailureEmitter(Path("artifacts/audit/failures"))
+
+    if not args.audit_spec.exists():
+        emitter.emit(
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Audit bundle spec missing",
+                phase_id="validate",
+                evidence={"path": str(args.audit_spec)},
+            ),
+            run_id=args.run_id,
+        )
+        print("Audit bundle build failed")
+        return 1
+
+    spec = load_audit_spec(args.audit_spec)
+    bundle_dir = args.bundle_dir / args.run_id
+    build_bundle(
+        spec=spec,
+        run_id=args.run_id,
+        bundle_dir=bundle_dir,
+        manifest_path=args.manifest_path,
+    )
+
+    print("Audit bundle build passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_readiness_validation.py
+++ b/scripts/audit_readiness_validation.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from generator.audit_bundle import validate_bundle
+from generator.failure_emitter import FailureEmitter, FailureLabel
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate audit bundle readiness.")
+    parser.add_argument(
+        "--manifest-path",
+        type=Path,
+        default=Path("artifacts/audit/audit_bundle_manifest.json"),
+        help="Audit bundle manifest path.",
+    )
+    parser.add_argument(
+        "--certificate-path",
+        type=Path,
+        default=Path("artifacts/audit/audit_certificate.json"),
+        help="Audit certificate output path.",
+    )
+    parser.add_argument("--run-id", type=str, default="audit-validate", help="Run identifier.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    emitter = FailureEmitter(Path("artifacts/audit/failures"))
+
+    if not args.manifest_path.exists():
+        emitter.emit(
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Audit bundle manifest missing",
+                phase_id="validate",
+                evidence={"path": str(args.manifest_path)},
+            ),
+            run_id=args.run_id,
+        )
+        print("Audit readiness validation failed")
+        return 1
+
+    manifest = json.loads(args.manifest_path.read_text(encoding="utf-8"))
+    results = validate_bundle(manifest)
+    if results["status"] != "pass":
+        emitter.emit(
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Audit bundle validation failed",
+                phase_id="validate",
+                evidence={"errors": results.get("errors", [])},
+            ),
+            run_id=args.run_id,
+        )
+        print("Audit readiness validation failed")
+        return 1
+
+    certificate = {
+        "anchor": {
+            "anchor_id": "audit_certificate",
+            "anchor_version": "1.0.0",
+            "scope": "run",
+            "owner": "scripts.audit_readiness_validation",
+            "status": "draft",
+        },
+        "run_id": manifest.get("run_id"),
+        "bundle_hash": manifest.get("bundle_hash"),
+        "coverage": {
+            "bundle_complete": True,
+            "hash_integrity": True,
+            "consistency_checks": True,
+        },
+        "gating_summary": {
+            "audit_readiness_validation": "pass",
+        },
+    }
+    args.certificate_path.parent.mkdir(parents=True, exist_ok=True)
+    args.certificate_path.write_text(json.dumps(certificate, indent=2), encoding="utf-8")
+
+    print("Audit readiness validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/budget_validation.py
+++ b/scripts/budget_validation.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from generator.budgeting import collect_artifact_sizes, evaluate_budgets, load_budget_spec
+from generator.failure_emitter import FailureEmitter, FailureLabel
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Validate performance budgets.")
+    parser.add_argument(
+        "--budget-spec",
+        type=Path,
+        default=Path("governance/budget_spec.json"),
+        help="Budget specification path.",
+    )
+    parser.add_argument(
+        "--telemetry-path",
+        type=Path,
+        default=Path("artifacts/telemetry/run_telemetry.json"),
+        help="Run telemetry path.",
+    )
+    parser.add_argument(
+        "--output-path",
+        type=Path,
+        default=Path("artifacts/budgets/budget_report.json"),
+        help="Output path for budget report.",
+    )
+    parser.add_argument(
+        "--schema-dir",
+        type=Path,
+        default=Path("schemas"),
+        help="Schema directory.",
+    )
+    parser.add_argument("--run-id", type=str, default="budget-validate", help="Run identifier.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    emitter = FailureEmitter(Path("artifacts/budgets/failures"))
+
+    if not args.budget_spec.exists():
+        emitter.emit(
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Budget specification missing",
+                phase_id="validate",
+                evidence={"path": str(args.budget_spec)},
+            ),
+            run_id=args.run_id,
+        )
+        print("Budget validation failed")
+        return 1
+
+    spec = load_budget_spec(args.budget_spec)
+    schema = json.loads((args.schema_dir / "budget-spec.json").read_text(encoding="utf-8"))
+    errors = sorted(Draft202012Validator(schema).iter_errors(spec), key=lambda e: e.path)
+    if errors:
+        emitter.emit(
+            FailureLabel(
+                Type="schema_failure",
+                message="Budget spec schema validation failed",
+                phase_id="validate",
+                evidence={
+                    "errors": [
+                        {"message": error.message, "path": list(error.path)} for error in errors
+                    ]
+                },
+            ),
+            run_id=args.run_id,
+        )
+        print("Budget validation failed")
+        return 1
+
+    if not args.telemetry_path.exists():
+        emitter.emit(
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Telemetry artifact missing for budget validation",
+                phase_id="validate",
+                evidence={"path": str(args.telemetry_path)},
+            ),
+            run_id=args.run_id,
+        )
+        print("Budget validation failed")
+        return 1
+
+    telemetry = json.loads(args.telemetry_path.read_text(encoding="utf-8"))
+    phase_durations = telemetry.get("phase_durations", {})
+    artifact_sizes = collect_artifact_sizes(spec.get("artifact_budgets", []))
+    report = evaluate_budgets(
+        budget_spec=spec,
+        phase_durations=phase_durations,
+        artifact_sizes=artifact_sizes,
+    )
+    report["anchor"] = {
+        "anchor_id": "budget_report",
+        "anchor_version": "1.0.0",
+        "scope": "run",
+        "owner": "scripts.budget_validation",
+        "status": "draft",
+    }
+    report["run_id"] = telemetry.get("run_id")
+    args.output_path.parent.mkdir(parents=True, exist_ok=True)
+    args.output_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    if report.get("status") != "pass":
+        emitter.emit(
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Budget validation failed",
+                phase_id="validate",
+                evidence={"violations": report.get("violations", [])},
+            ),
+            run_id=args.run_id,
+        )
+        print("Budget validation failed")
+        return 1
+
+    print("Budget validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/docs_repro_check.py
+++ b/scripts/docs_repro_check.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+from generator.failure_emitter import FailureEmitter, FailureLabel
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run documentation reproducibility checks.")
+    parser.add_argument(
+        "--runbook-path",
+        type=Path,
+        default=Path("docs/runbook.json"),
+        help="Runbook JSON path.",
+    )
+    parser.add_argument("--run-id", type=str, default="docs-repro", help="Run identifier.")
+    return parser.parse_args()
+
+
+def _load_runbook(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    args = _parse_args()
+    emitter = FailureEmitter(Path("artifacts/docs/failures"))
+
+    if not args.runbook_path.exists():
+        emitter.emit(
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Runbook is missing",
+                phase_id="validate",
+                evidence={"path": str(args.runbook_path)},
+            ),
+            run_id=args.run_id,
+        )
+        print("Docs repro check failed")
+        return 1
+
+    runbook = _load_runbook(args.runbook_path)
+    for step in runbook.get("steps", []):
+        command = step.get("command")
+        if not command:
+            continue
+        proc = subprocess.run(command, shell=True, check=False)
+        if proc.returncode != 0:
+            emitter.emit(
+                FailureLabel(
+                    Type="reproducibility_failure",
+                    message="Runbook command failed",
+                    phase_id="validate",
+                    evidence={"command": command},
+                ),
+                run_id=args.run_id,
+            )
+            print("Docs repro check failed")
+            return 1
+        for expected in step.get("expected_paths", []):
+            if not Path(expected).exists():
+                emitter.emit(
+                    FailureLabel(
+                        Type="reproducibility_failure",
+                        message="Runbook expected output missing",
+                        phase_id="validate",
+                        evidence={"path": expected},
+                    ),
+                    run_id=args.run_id,
+                )
+                print("Docs repro check failed")
+                return 1
+
+    print("Docs repro check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/secrets_redaction_validation.py
+++ b/scripts/secrets_redaction_validation.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from generator.failure_emitter import FailureEmitter, FailureLabel
+from generator.secret_scanner import load_allowlist, scan_paths
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Scan repo artifacts for secret exposure.")
+    parser.add_argument(
+        "--scan-dirs",
+        type=Path,
+        nargs="+",
+        default=[Path("artifacts"), Path("data"), Path("docs"), Path("overlays")],
+        help="Directories to scan for secret exposure.",
+    )
+    parser.add_argument(
+        "--scan-files",
+        type=Path,
+        nargs="*",
+        default=[Path("config/anchor_registry.json")],
+        help="Additional files to scan for secret exposure.",
+    )
+    parser.add_argument(
+        "--allowlist-path",
+        type=Path,
+        default=Path("governance/secret_allowlist.json"),
+        help="Allowlist path for scoped secret exceptions.",
+    )
+    parser.add_argument("--run-id", type=str, default="secrets-scan", help="Run identifier.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    emitter = FailureEmitter(Path("artifacts/redaction/failures"))
+    allowlist = load_allowlist(args.allowlist_path)
+    scan_targets = list(args.scan_dirs) + list(args.scan_files)
+
+    results = scan_paths(scan_targets, allowlist=allowlist)
+    violations = results["violations"]
+    allowlist_errors = results["allowlist_errors"]
+
+    if violations or allowlist_errors:
+        emitter.emit(
+            FailureLabel(
+                Type="reproducibility_failure",
+                message="Secret scanning gate detected sensitive content",
+                phase_id="validate",
+                evidence={"violations": violations, "allowlist_errors": allowlist_errors},
+            ),
+            run_id=args.run_id,
+        )
+        print("Secrets redaction validation failed")
+        return 1
+
+    print("Secrets redaction validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_policy.py
+++ b/tests/test_agent_policy.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from generator.agent_policy import find_prohibited_commands, is_prohibited_command
+
+
+def test_prohibited_command_detection() -> None:
+    assert is_prohibited_command("ls -R")
+    assert is_prohibited_command("grep -R pattern file")
+    assert not is_prohibited_command("ls -a")
+
+
+def test_find_prohibited_commands_filters_list() -> None:
+    commands = ["ls -R", "ls -a", "grep -R foo bar"]
+    prohibited = find_prohibited_commands(commands)
+    assert prohibited == ["ls -R", "grep -R foo bar"]

--- a/tests/test_budgeting.py
+++ b/tests/test_budgeting.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from generator.budgeting import evaluate_budgets
+
+
+def test_evaluate_budgets_passes_within_limits() -> None:
+    spec = {
+        "phase_budgets": {"ingest": {"max_duration_sec": 10}},
+        "artifact_budgets": [
+            {"artifact_class": "telemetry", "paths": ["x"], "max_size_mb": 1}
+        ],
+        "max_total_duration_sec": 20,
+    }
+    report = evaluate_budgets(
+        budget_spec=spec,
+        phase_durations={"ingest": 5},
+        artifact_sizes=[
+            {
+                "artifact_class": "telemetry",
+                "paths": ["x"],
+                "size_bytes": 1024,
+                "missing": [],
+                "max_size_mb": 1,
+            }
+        ],
+    )
+    assert report["status"] == "pass"
+
+
+def test_evaluate_budgets_fails_on_missing_artifacts() -> None:
+    spec = {
+        "phase_budgets": {"ingest": {"max_duration_sec": 10}},
+        "artifact_budgets": [
+            {"artifact_class": "telemetry", "paths": ["x"], "max_size_mb": 1}
+        ],
+        "max_total_duration_sec": 20,
+    }
+    report = evaluate_budgets(
+        budget_spec=spec,
+        phase_durations={"ingest": 5},
+        artifact_sizes=[
+            {
+                "artifact_class": "telemetry",
+                "paths": ["x"],
+                "size_bytes": 0,
+                "missing": ["x"],
+                "max_size_mb": 1,
+            }
+        ],
+    )
+    assert report["status"] == "fail"

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from generator.sanitizer import redact_text, sanitize_payload
+
+
+def test_redact_text_masks_secrets_and_truncates() -> None:
+    secret = "sk-ABCDEFGHIJKLMNOPQRSTUV0123456789"
+    long_text = "a" * 300
+    combined = f"{secret} {long_text}"
+    redacted = redact_text(combined)
+    assert "[REDACTED]" in redacted
+    assert redacted.endswith("...[TRUNCATED]")
+
+
+def test_sanitize_payload_redacts_sensitive_keys() -> None:
+    payload = {"token": "secret", "nested": {"password": "value"}}
+    sanitized = sanitize_payload(payload)
+    assert sanitized["token"] == "[REDACTED]"
+    assert sanitized["nested"]["password"] == "[REDACTED]"

--- a/tests/test_secret_scanner.py
+++ b/tests/test_secret_scanner.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from generator.secret_scanner import load_allowlist, scan_paths
+
+
+def test_secret_scanner_flags_env_file(tmp_path: Path) -> None:
+    env_file = tmp_path / ".env"
+    env_file.write_text("TOKEN=secret", encoding="utf-8")
+    results = scan_paths([tmp_path], allowlist=[])
+    assert results["violations"]
+
+
+def test_secret_scanner_respects_allowlist(tmp_path: Path) -> None:
+    secret_file = tmp_path / "artifact.txt"
+    secret_file.write_text("token=secret", encoding="utf-8")
+    allowlist_path = tmp_path / "allowlist.json"
+    allowlist_path.write_text(
+        json.dumps(
+            {
+                "entries": [
+                    {
+                        "entry_id": "allow-1",
+                        "path_glob": str(secret_file),
+                        "pattern": "(?i)token\\s*[:=]",
+                        "scope": "tests",
+                        "expires_at": "2999-01-01T00:00:00Z",
+                        "approved_by": "security",
+                        "approval_ref": "remediation-15",
+                        "allow_on_canonical": False,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    allowlist = load_allowlist(allowlist_path)
+    results = scan_paths([tmp_path], allowlist=allowlist)
+    assert not results["violations"]


### PR DESCRIPTION
### Motivation
- Enforce Remediations by preventing secret leakage, enforcing agent policy precedence, budget gates, docs reproducibility, and audit bundle readiness during promotion.
- Provide deterministic, anchored redaction and evidence sanitization so failure labels and telemetry never leak sensitive data.
- Emit per-run manifests (policy, budget, audit) and integrate them into the promotion readiness pipeline for auditability and gating.
- Supply overlay-only governance artifacts and schemas so policy and budget evolution follow the repository overlay model.

### Description
- Added a deterministic sanitizer (`generator/sanitizer.py`) and updated `generator/failure_emitter.py` to sanitize all emitted failure labels and contexts via `sanitize_payload`.
- Implemented secret scanning and allowlist logic (`generator/secret_scanner.py` and `scripts/secrets_redaction_validation.py`) that scans generated layers and anchor registries and forbids allowlisting canonical artifacts.
- Added agent policy enforcement (`generator/agent_policy.py`, `scripts/agents_policy_validation.py`) to validate AGENTS.md presence, detect prohibited commands, and emit `artifacts/policy/policy_manifest.json` per run.
- Added budgeting and budget gate tooling (`generator/budgeting.py`, `scripts/budget_validation.py`, `governance/budget_spec.json`, schemas) and integrated budget reporting into the promotion readiness flow.
- Added audit bundle builder/validator (`generator/audit_bundle.py`, `scripts/audit_bundle_builder.py`, `scripts/audit_readiness_validation.py`) and a canonical `governance/audit_bundle_spec.json` to produce and validate evidence bundles and certificates.
- Extended `scripts/run_promotion_readiness.py` to generate sanitized telemetry, policy manifest, budget report, audit bundle/certificate, and to run docs reproducibility checks and secret scanning as hard gates.
- Added anchored governance artifacts, schemas, docs (runbook, artifact glossary, schema overlay map, onboarding checklist), and unit tests for the new modules (`tests/test_sanitizer.py`, `tests/test_secret_scanner.py`, `tests/test_agent_policy.py`, `tests/test_budgeting.py`).

### Testing
- ⚠️ No automated tests were executed as part of this rollout (CI was not invoked during the change set). 
- ⚠️ New unit tests were added under `tests/`: `test_sanitizer.py`, `test_secret_scanner.py`, `test_agent_policy.py`, and `test_budgeting.py`, but they have not been run in CI yet.
- ✅ Static integration: `scripts/run_promotion_readiness.py` was updated to call the new gates and will emit `artifacts/policy/policy_manifest.json`, `artifacts/budgets/budget_report.json`, and `artifacts/audit/audit_bundle_manifest.json` when executed (verification to be performed by CI runs).
- ⚠️ Recommendation: run the full test suite (`pytest`) and execute `scripts/run_promotion_readiness.py --run-id <id>` in CI to validate gate behavior and confirm all new tests pass before promotion.
