### PR TITLE
Implement stable public workflows API with PDL-backed validation

### DIFF
--- a/API/workflows.py
+++ b/API/workflows.py
@@ -2,10 +2,12 @@
 # -*- coding: utf-8 -*-
 """
 API.workflows — High-Level Workflow Interfaces
-SSWG-MVM v.09.mvm.25
+sswg-mvm v.09.mvm.25
+
+Public API: stable
 
 This module provides a programmatic interface for loading, validating,
-refining, exporting, and inspecting SSWG workflow objects.
+refining, exporting, and inspecting sswg workflow objects.
 
 It is a thin integration layer across:
     - generator.main
@@ -30,12 +32,16 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 # Core pipeline
-from generator.main import run_mvm, load_workflow, process_workflow
+from generator.pdl_validator import (
+    PDLValidationError,
+    validate_pdl_file,
+    validate_pdl_object,
+)
 
 # Validation
 from ai_validation.schema_validator import validate_workflow
 
-# Refiner (MVM-lite recursion)
+# Refiner (mvm-lite recursion)
 from generator.recursion_manager import simple_refiner
 
 # Exporters
@@ -71,5 +77,137 @@ def load_template(slug: str) -> Dict[str, Any]:
 # ------------------------------------------------------------
 # VALIDATION
 # ------------------------------------------------------------
-def validate(workflow: Dict[str, Any]) -> tuple[bool, str]:
+def validate(
+    workflow: Dict[str, Any],
+    *,
+    pdl: Dict[str, Any] | str | Path | None = None,
+) -> tuple[bool, str]:
     """
+    Public API: stable
+
+    Validate a workflow dictionary against the workflow schema and
+    optionally validate a PDL document when supplied.
+
+    Returns:
+        (ok, message)
+        ok: bool — True if validation passed
+        message: details or "ok"
+    """
+    ok, errors = validate_workflow(workflow)
+    if not ok:
+        return False, _format_schema_errors(errors)
+
+    if pdl is None:
+        return True, "ok"
+
+    try:
+        if isinstance(pdl, (str, Path)):
+            validate_pdl_file(Path(pdl))
+        else:
+            validate_pdl_object(pdl)
+    except PDLValidationError as exc:
+        return False, json.dumps(exc.label.as_dict(), indent=2)
+
+    return True, "ok"
+
+
+def _format_schema_errors(errors: Optional[list[Any]]) -> str:
+    if not errors:
+        return "Schema validation failed."
+    return "; ".join(
+        f"{error.message} at {list(error.path)}" for error in errors
+    )
+
+
+def refine(
+    workflow: Dict[str, Any],
+    *,
+    depth: int = 1,
+    out_dir: str | Path = "data/outputs",
+) -> Dict[str, Any]:
+    """
+    Public API: stable
+
+    Perform recursive refinement passes using the mvm refiner.
+    """
+    refined = workflow
+    for _ in range(max(depth, 0)):
+        refined = simple_refiner(refined, output_dir=Path(out_dir))
+    return refined
+
+
+def export(
+    workflow: Dict[str, Any],
+    *,
+    out_dir: str | Path = "data/outputs",
+) -> Dict[str, str]:
+    """
+    Public API: stable
+
+    Export workflow artifacts to JSON and Markdown.
+    """
+    out_dir_str = str(out_dir)
+    return {
+        "json": export_json(workflow, out_dir_str),
+        "markdown": export_markdown(workflow, out_dir_str),
+    }
+
+
+def generate_mermaid(workflow: Dict[str, Any]) -> str:
+    """
+    Public API: stable
+
+    Generate a Mermaid diagram representation of a workflow.
+    """
+    return mermaid_from_workflow(workflow)
+
+
+def get_metadata(workflow: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Public API: stable
+
+    Return the metadata section of the workflow.
+    """
+    return dict(workflow.get("metadata", {}) or {})
+
+
+def get_phases(workflow: Dict[str, Any]) -> list[Dict[str, Any]]:
+    """
+    Public API: stable
+
+    Return the workflow phases list.
+    """
+    phases = workflow.get("phases", []) or []
+    return list(phases)
+
+
+def get_dependency_graph(workflow: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Public API: stable
+
+    Return the dependency graph if present, otherwise build a simple graph
+    from module dependencies.
+    """
+    dependency_graph = workflow.get("dependency_graph")
+    if isinstance(dependency_graph, dict):
+        return dict(dependency_graph)
+    modules = workflow.get("modules", []) or []
+    return _build_dependency_graph(modules)
+
+
+def _build_dependency_graph(modules: list[Dict[str, Any]]) -> Dict[str, Any]:
+    nodes = sorted(
+        {
+            str(module.get("module_id"))
+            for module in modules
+            if module.get("module_id")
+        }
+    )
+    edges: list[list[str]] = []
+    for module in modules:
+        module_id = module.get("module_id")
+        if not module_id:
+            continue
+        for dep in module.get("dependencies", []) or []:
+            edges.append([str(dep), str(module_id)])
+    return {"nodes": nodes, "edges": edges}


### PR DESCRIPTION
### Motivation
- `API/workflows.py` previously exposed an incomplete `validate()` surface that created a broken public contract. 
- External integrators need a stable programmatic surface for loading, validating, refining, exporting, and inspecting workflows. 
- Validation must bind to canonical schema validation and optional PDL validation to satisfy reproducibility/schema gates. 
- Normalize naming and mark the module as a stable public API to reduce false assumptions about stability.

### Description
- Implemented `validate()` to call `ai_validation.schema_validator.validate_workflow` and added optional `pdl` validation via `generator.pdl_validator` returning `(bool, message)`.
- Added stable helpers: `refine()`, `export()`, `generate_mermaid()`, `get_metadata()`, `get_phases()`, and `get_dependency_graph()` for common programmatic operations.
- Added `_format_schema_errors()` plus handling of `PDLValidationError` to surface structured PDL failure labels (via `exc.label.as_dict()`).
- Updated module docstring to `Public API: stable` and normalized references to `sswg`/`mvm` naming and doc comments.

### Testing
- ⚠️ No automated test suite was executed as part of this change; tests were not run. 
- ✅ Static inspection confirmed `API/workflows.py` references `validate_workflow` and `generator.pdl_validator` and exposes the new helper functions. 
- ⚠️ Recommended checks for consumers: `python -m pytest` and `python -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas`. 
- ✅ Basic import/static-sanity checks (code read and function signatures) completed successfully.
