### PR TITLE
Add `project.toml` metadata and anchor for `api_contract.yaml`

### DIFF
--- a/api_contract.yaml
+++ b/api_contract.yaml
@@ -1,0 +1,26 @@
+anchor:
+  anchor_id: api-contract
+  anchor_version: 0.0.9mvm
+  scope: repo
+  owner: Raven Recordings
+  status: draft
+
+public:
+  - generator/main.py
+  - generator.main.run_mvm
+  - generator/pdl_validator.py
+
+compliance_internal:
+  - scripts/run_promotion_readiness.py
+  - scripts/validate_pdl_artifacts.py
+  - scripts/replay_determinism_gate.py
+  - scripts/audit_bundle_builder.py
+
+developer_internal:
+  - ai_core/cli.py
+  - ai_validation/*
+  - ai_visualization/*
+
+experimental:
+  - config/cli.py
+  - API/workflows.py

--- a/project.toml
+++ b/project.toml
@@ -1,0 +1,28 @@
+[anchor]
+anchor_id = "project-toml"
+anchor_version = "0.0.9mvm"
+scope = "repo"
+owner = "Raven Recordings"
+status = "draft"
+
+[project]
+name = "sswg-mvm"
+version = "0.0.9mvm"
+status = "active"
+release_stage = "pre-release"
+description = "sswg mvm is the minimum viable model for the sswg workflow generation system."
+
+[system]
+component = "sswg"
+minimum_viable_model = "mvm"
+
+[runtime]
+python = ">=3.10"
+
+[licensing]
+license = "proprietary (pre-release)"
+terms = "TERMS_OF_USE.md"
+
+[repository]
+url = "https://github.com/Tommy-Raven/SSWG-mvm1.0"
+default_branch = "work"


### PR DESCRIPTION
### Motivation
- Make repository status explicit by adding a canonical `project.toml` with project metadata and anchor information.
- Provide a canonical anchor in `api_contract.yaml` so API tiering is tied to a tracked repo anchor version.
- Surface the intended public, internal, and experimental API surfaces to reduce accidental contract expansion.
- Ensure runtime and licensing metadata (Python requirement, license, default branch) are recorded in the repo manifest.

### Description
- Add `project.toml` containing anchor metadata and project fields including `name`, `version`, `status`, `runtime` and `repository` details.
- Add an `anchor` block to `api_contract.yaml` and populate API tier listings under `public`, `compliance_internal`, `developer_internal`, and `experimental`.
- Declare explicit public entries such as `generator/main.py` and `generator.main.run_mvm` and internal scripts under the respective tiers in `api_contract.yaml`.
- Record repository defaults like `default_branch = "work"` and `python = ">=3.10"` in `project.toml`.

### Testing
- No automated tests were executed for this change.
- No `pytest` or CI runs were triggered as part of this update.
- Changes were limited to metadata and YAML/TOML additions only, with no runtime code modified.
- Validation of file syntax (TOML/YAML) was not performed automatically