### PR TITLE
Move visualization demos into examples and remove demo __main__ writers

### DIFF
--- a/ai_visualization/export_manager.py
+++ b/ai_visualization/export_manager.py
@@ -126,20 +126,3 @@ def export_workflow(wf: dict, export_mode: str = "json") -> dict:
     return results
 
 
-# ---------------------- Example Execution ---------------------- #
-
-if __name__ == "__main__":
-    # Demo placeholder workflow
-    wf_demo = {
-        "workflow_id": "demo_workflow",
-        "version": "1.0",
-        "metadata": {"purpose": "Testing export manager", "audience": "Developers"},
-        "phases": [
-            {"title": "Phase 1: Initialization", "tasks": ["Collect user inputs", "Load template"]},
-            {"title": "Phase 2: Generation", "tasks": ["Assemble structure", "Export results"]}
-        ],
-        "dependency_graph": {"nodes": ["Init", "Generate"], "edges": [["Init", "Generate"]]}
-    }
-
-    exported = export_workflow(wf_demo, export_mode="both")
-    print("Export complete:", exported)

--- a/ai_visualization/markdown_importer.py
+++ b/ai_visualization/markdown_importer.py
@@ -99,12 +99,3 @@ def import_markdown(md_path: str, out_dir: str = "./data/workflows") -> str:
     print(f"🪶 Imported Markdown workflow saved as JSON → {out_path}")
     return out_path
 
-
-# ---------------------- Example Execution ---------------------- #
-
-if __name__ == "__main__":
-    demo_md = "./build/workflow_demo.md"
-    if os.path.exists(demo_md):
-        import_markdown(demo_md)
-    else:
-        print("No demo Markdown file found. Run export_manager first.")

--- a/ai_visualization/mermaid_generator.py
+++ b/ai_visualization/mermaid_generator.py
@@ -75,22 +75,4 @@ def mermaid_from_workflow(workflow: Dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-if __name__ == "__main__":
-    # Minimal manual test example; safe to delete if you don't want it
-    example = {
-        "workflow_id": "wf_example",
-        "modules": [
-            {
-                "module_id": "m1",
-                "name": "Start",
-                "dependencies": []
-            },
-            {
-                "module_id": "m2",
-                "name": "Next step",
-                "dependencies": ["m1"]
-            },
-        ],
-    }
-    print(mermaid_from_workflow(example))
 # End of ai_visualization/mermaid_generator.py

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Examples
+
+These scripts demonstrate how to run the visualization utilities without
+embedding file-writing demo blocks in library modules.
+
+## Expected inputs/outputs
+
+- `export_workflow_demo.py` writes Graphviz, JSON, and Markdown workflow exports
+  under `./build/` with timestamped filenames.
+- `import_markdown_demo.py` reads a Markdown workflow file (default
+  `./build/workflow_demo.md`) and writes a JSON workflow export under
+  `./data/workflows/`.
+- `mermaid_demo.py` prints a Mermaid flowchart to stdout and does not write
+  files.
+
+Run them from the repository root so the default relative paths resolve.

--- a/examples/export_workflow_demo.py
+++ b/examples/export_workflow_demo.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""
+Export workflow demo.
+
+Outputs:
+- Graphviz DOT, JSON, and Markdown files under ./build/ with timestamped names.
+"""
+
+from ai_visualization.export_manager import export_workflow
+
+
+def main() -> None:
+    wf_demo = {
+        "workflow_id": "demo_workflow",
+        "version": "1.0",
+        "metadata": {"purpose": "Testing export manager", "audience": "Developers"},
+        "phases": [
+            {"title": "Phase 1: Initialization", "tasks": ["Collect user inputs", "Load template"]},
+            {"title": "Phase 2: Generation", "tasks": ["Assemble structure", "Export results"]},
+        ],
+        "dependency_graph": {"nodes": ["Init", "Generate"], "edges": [["Init", "Generate"]]},
+    }
+
+    exported = export_workflow(wf_demo, export_mode="both")
+    print("Export complete:", exported)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/import_markdown_demo.py
+++ b/examples/import_markdown_demo.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""
+Markdown import demo.
+
+Inputs:
+- Markdown workflow file at ./build/workflow_demo.md (update as needed).
+
+Outputs:
+- JSON workflow export under ./data/workflows/ with a timestamped filename.
+"""
+
+import os
+
+from ai_visualization.markdown_importer import import_markdown
+
+
+def main() -> None:
+    demo_md = "./build/workflow_demo.md"
+    if os.path.exists(demo_md):
+        import_markdown(demo_md)
+    else:
+        print(f"No demo Markdown file found at {demo_md}. Run export_workflow_demo first.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mermaid_demo.py
+++ b/examples/mermaid_demo.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""
+Mermaid generator demo.
+
+Outputs:
+- Mermaid flowchart printed to stdout.
+"""
+
+from ai_visualization.mermaid_generator import mermaid_from_workflow
+
+
+def main() -> None:
+    example = {
+        "workflow_id": "wf_example",
+        "modules": [
+            {"module_id": "m1", "name": "Start", "dependencies": []},
+            {"module_id": "m2", "name": "Next step", "dependencies": ["m1"]},
+        ],
+    }
+    print(mermaid_from_workflow(example))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation

- Prevent library modules from performing file writes on direct execution by removing embedded demo `__main__` blocks.
- Centralize runnable examples to make demos discoverable and safe to run from the repository root.
- Reduce accidental side effects when importing visualization utilities in tests or other code.

### Description

- Removed demo execution blocks from `ai_visualization/export_manager.py`, `ai_visualization/markdown_importer.py`, and `ai_visualization/mermaid_generator.py` so the modules no longer write files when invoked directly. 
- Added an `examples/` directory containing `export_workflow_demo.py`, `import_markdown_demo.py`, `mermaid_demo.py`, and `README.md` that document expected inputs/outputs and perform the previous demo actions.
- Kept original function APIs (e.g., `export_workflow`, `import_markdown`, `mermaid_from_workflow`) unchanged so callers are unaffected.
