### PR TITLE
Standardize orchestrator entrypoint with RunContext and run_mvm

### DIFF
--- a/ai_core/cli.py
+++ b/ai_core/cli.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, Optional
 
 from .workflow import Workflow
 from .module_registry import ModuleRegistry
-from .orchestrator import Orchestrator
+from .orchestrator import Orchestrator, RunContext
 
 
 def parse_args(argv: Optional[list] = None) -> argparse.Namespace:
@@ -83,10 +83,13 @@ def main(argv: Optional[list] = None) -> int:
 
     # If phases are provided, the orchestrator should accept a subset;
     # at MVM this can be a hint the implementation can ignore.
-    orchestrator.run(workflow, phases=args.phases)
+    context = RunContext(workflow_source=workflow, phases=args.phases)
+    result = orchestrator.run_mvm(context)
 
     # Optional: print a short summary
-    print(f"Workflow {workflow.id} executed via ai_core.Orchestrator.")
+    print(
+        f"Workflow {result.workflow.id} executed via ai_core.Orchestrator."
+    )
     return 0
 
 

--- a/config/cli.py
+++ b/config/cli.py
@@ -3,7 +3,8 @@
 """Command-line entrypoint for generating instructional workflows."""
 
 import argparse
-from ai_core.orchestrator import Orchestrator
+
+from ai_core.orchestrator import Orchestrator, RunContext
 
 def main():
     parser = argparse.ArgumentParser(description="AI Instructional Workflow CLI")
@@ -11,9 +12,14 @@ def main():
     parser.add_argument("--audience", default="General")
     args = parser.parse_args()
 
-    orch = Orchestrator()
-    wf = orch.run(vars(args))
-    print("Workflow generated:", wf["workflow_id"])
+    workflow_payload = {
+        "workflow_id": f"config_cli_{args.purpose.lower().replace(' ', '_')}",
+        "params": {"purpose": args.purpose, "audience": args.audience},
+    }
+    orchestrator = Orchestrator()
+    context = RunContext(workflow_source=workflow_payload)
+    result = orchestrator.run_mvm(context)
+    print("Workflow generated:", result.workflow.id)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### Motivation
- Multiple CLIs were calling `Orchestrator.run(...)` with different argument shapes, creating an implicit and brittle orchestrator contract.
- This fragmentation increases the risk that changes to the orchestrator break callers unpredictably.
- Provide a single, explicit programmatic entrypoint so callers adapt to a stable contract rather than the orchestrator adapting to callers.

### Description
- Add `RunContext` and `RunResult` dataclasses and a canonical `Orchestrator.run_mvm(context: RunContext) -> RunResult` entrypoint in `ai_core/orchestrator.py`, and add `_load_workflow_source` and `last_phase_status` tracking for consistent result reporting. 
- Preserve `Orchestrator.run(...)` for direct in-process orchestration so existing codepaths remain usable while standardizing the external contract. 
- Update CLIs to use the new context-based entrypoint: `ai_core/cli.py` now builds a `RunContext` and calls `orchestrator.run_mvm(...)`, `config/cli.py` constructs a payload and uses `RunContext`, and `generator/main.py` invokes `run_mvm` via `RunContext` with `runner`/`runner_kwargs` to preserve prior `run_mvm` semantics. 
- Changes confined to `ai_core/orchestrator.py`, `ai_core/cli.py`, `config/cli.py`, and `generator/main.py` to centralize the orchestration contract.
