### PR TITLE
Align invariants source and enforce parity checks

### DIFF
--- a/docs/INVARIANTS.md
+++ b/docs/INVARIANTS.md
@@ -1,0 +1,13 @@
+---
+anchor_id: invariants-doc
+anchor_version: "1.0"
+scope: documentation
+owner: sswg
+status: draft
+---
+
+# Canonical invariants source
+
+`invariants.yaml` is the canonical source of truth for sswg/mvm invariants.
+`root_contract.yaml` must reference `invariants.yaml` and mirror its invariant
+entries exactly; parity is enforced by `scripts/validate_root_contracts.py`.

--- a/invariants.yaml
+++ b/invariants.yaml
@@ -15,3 +15,8 @@ invariants:
   - id: validation_required
     rule: >
       Outputs that fail validation must not be promoted or reused.
+
+  - id: quarantine_on_failure
+    rule: >
+      Workflows with critical or major incidents must remain quarantined
+      until recovery steps complete and validation passes.

--- a/root_contract.yaml
+++ b/root_contract.yaml
@@ -189,6 +189,8 @@ root_contract:
         - phase_validation
         - reproducibility_validation
 
+  invariants_source: invariants.yaml
+
   invariants:
     - id: deterministic_measurement
       rule: >

--- a/schemas/root_contract_schema.json
+++ b/schemas/root_contract_schema.json
@@ -9,7 +9,14 @@
     "root_contract": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["sswg", "mvm", "execution_policy", "governance", "invariants"],
+      "required": [
+        "sswg",
+        "mvm",
+        "execution_policy",
+        "governance",
+        "invariants_source",
+        "invariants"
+      ],
       "properties": {
         "sswg": {
           "$ref": "sswg_contract_schema.json#/properties/sswg"
@@ -22,6 +29,10 @@
         },
         "governance": {
           "$ref": "governance_schema.json#/properties/governance"
+        },
+        "invariants_source": {
+          "type": "string",
+          "minLength": 1
         },
         "invariants": {
           "$ref": "invariants_schema.json#/properties/invariants"

--- a/scripts/validate_root_contracts.py
+++ b/scripts/validate_root_contracts.py
@@ -57,6 +57,30 @@ def validate_contracts() -> int:
                 path = "/".join(str(part) for part in error.path)
                 failures.append(f"{yaml_name}: {path or '<root>'}: {error.message}")
 
+    root_contract_path = ROOT_DIR / "root_contract.yaml"
+    invariants_path = ROOT_DIR / "invariants.yaml"
+    if root_contract_path.exists() and invariants_path.exists():
+        root_contract = load_yaml(root_contract_path)
+        invariants_doc = load_yaml(invariants_path)
+        root_invariants = root_contract.get("root_contract", {}).get("invariants")
+        invariants_source = root_contract.get("root_contract", {}).get("invariants_source")
+        canonical_invariants = invariants_doc.get("invariants")
+
+        if invariants_source != "invariants.yaml":
+            failures.append(
+                "root_contract.yaml: root_contract/invariants_source must be invariants.yaml"
+            )
+
+        if not isinstance(root_invariants, list) or not isinstance(canonical_invariants, list):
+            failures.append("root_contract.yaml: invariants must be a list in both files")
+        else:
+            root_map = {item.get("id"): item.get("rule") for item in root_invariants}
+            canonical_map = {item.get("id"): item.get("rule") for item in canonical_invariants}
+            if root_map != canonical_map:
+                failures.append(
+                    "root_contract.yaml: invariants do not match invariants.yaml"
+                )
+
     if failures:
         print("root contract validation failures:")
         for failure in failures:


### PR DESCRIPTION
### Motivation

- Establish a single authoritative invariants source and ensure `root_contract.yaml` references it without divergence.  
- Add the missing `quarantine_on_failure` invariant that is currently present in `root_contract.yaml` but absent from `invariants.yaml`.  
- Enforce automated parity so the validator will detect divergence between `root_contract.yaml` and the canonical `invariants.yaml`.  
- Document the canonical source to make the policy explicit for contributors and tooling.

### Description

- Added `quarantine_on_failure` to `invariants.yaml` (canonical invariants list).  
- Added `invariants_source: invariants.yaml` to `root_contract.yaml` and kept the invariant entries mirrored.  
- Updated `schemas/root_contract_schema.json` to require `invariants_source` and `invariants`.  
- Extended `scripts/validate_root_contracts.py` to assert `root_contract.yaml` references `invariants.yaml` and that the invariant lists are identical, and added `docs/INVARIANTS.md` documenting `invariants.yaml` as the canonical source.
