### PR TITLE
Reference canonical invariants in docs and align terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Author: **Tommy Raven (Thomas Byers)**
 Workflows become seeds for subsequent generations.
 
 ### Schema Integrity  
-Strict JSON schema validation guarantees reproducibility.
+Strict JSON schema validation enforces schema validation invariants that support reproducibility. See the canonical definitions in [invariants.yaml](invariants.yaml) and [root_contract.yaml](root_contract.yaml).
 
 ### Modularity  
 Phases → tasks → dependencies → evaluation → refinement.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -100,7 +100,9 @@ This document defines:
 - recursion and feedback loops,
 - evaluation metrics,
 - demo pipeline structure,
-- and governance guarantees.
+- and governance invariants.
+
+Canonical invariants (including schema validation invariants) are defined in [invariants.yaml](../invariants.yaml) and detailed in [root_contract.yaml](../root_contract.yaml).
 
 ---
 

--- a/docs/architecture/system_architecture.md
+++ b/docs/architecture/system_architecture.md
@@ -8,7 +8,7 @@ Licensing: Raven Recordings ©️ see: *LICENSE.md*
 # 🏛 System Architecture
 ### SSWG-MVM — Synthetic Synthesist of Workflow Generation
 
-SSWG-MVM organizes itself as a **layered modular architecture**, balancing strict schema-driven control with dynamic recursive refinement.
+sswg-mvm organizes itself as a **layered modular architecture**, balancing strict schema-driven control with dynamic recursive refinement.
 
 ---
 
@@ -64,10 +64,12 @@ SSWG-MVM organizes itself as a **layered modular architecture**, balancing stric
 # ⚙ Design Principles
 
 ### **1. Deterministic core**
-Valid workflows must always meet schema guarantees:  
+Valid workflows must always meet schema validation invariants:  
 - metadata correctness  
 - phase order  
 - dependency graph validity  
+
+Canonical invariants are defined in [invariants.yaml](../../invariants.yaml) and expanded in [root_contract.yaml](../../root_contract.yaml).
 
 ### **2. Recursive refinement**
 The MVM includes a *minimal recursion engine* designed to:
@@ -87,7 +89,7 @@ schemas/workflow_schema.json
 This enables:
 
 - automated testing  
-- validation guarantees  
+- schema validation invariants  
 - version bump automation in CI  
 
 ### **4. Minimal external dependencies**  


### PR DESCRIPTION
### Motivation
- Ensure documentation consistently references the repository's canonical invariants and uses the canonical terminology rather than informal "guarantees".
- Make it clear where authoritative definitions live by linking user-facing docs to the canonical artifacts that define invariants and validation behavior.
- Reduce ambiguity between similarly named concepts by renaming references like "schema guarantees" to the canonical phrase "schema validation invariant".

### Description
- Updated `docs/architecture/system_architecture.md` to use lowercase `sswg-mvm`, replace "schema guarantees" with "schema validation invariants", and link to `invariants.yaml` and `root_contract.yaml`.
- Updated `docs/QUICKSTART.md` to change "governance guarantees" to "governance invariants" and add a link to `invariants.yaml` and `root_contract.yaml`.
- Updated `README.md` to change the schema wording to "schema validation invariants" and add links to `invariants.yaml` and `root_contract.yaml`.
- Aligned terminology across the three files to reference the canonical invariant definitions and preserve naming discipline (e.g., `sswg`/`mvm` casing).

### Testing
- No automated tests were executed because this is a documentation-only change affecting `README.md`, `docs/QUICKSTART.md`, and `docs/architecture/system_architecture.md`.
- Static checks and validation gates were not applicable for these modifications and therefore were not run.
