### PR TITLE
Add formal recursion termination guarantees docs and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ This section documents the concrete, implemented semantics used by the mvm
 runtime for recursive refinement and evaluation. It is intended to be
 machine-auditable and to mirror the behavior in `generator/recursion_manager.py`,
 `ai_recursive/recursion_manager.py`, and `ai_evaluation/quality_metrics.py`.
+The recursion policy described below is the authoritative behavior for
+termination and guardrails; formal guarantees and assumptions are documented in
+[docs/FORMAL_GUARANTEES.md](docs/FORMAL_GUARANTEES.md).
 
 ### Recursion Semantics (single-cycle refinement)
 Each recursion cycle executes the following steps:

--- a/docs/FORMAL_GUARANTEES.md
+++ b/docs/FORMAL_GUARANTEES.md
@@ -1,0 +1,53 @@
+---
+anchor:
+  anchor_id: formal_guarantees_docs
+  anchor_version: "1.0.0"
+  scope: docs
+  owner: docs
+  status: draft
+---
+
+# Formal guarantees
+
+## Scope
+
+This document records the formal guarantees (or lack thereof) for recursion
+termination and convergence in the sswg mvm runtime. The recursion policy is
+summarized in the root [README](../README.md) and expanded in the architecture
+notes in [docs/architecture/recursion_engine.md](./architecture/recursion_engine.md).
+
+## Termination and convergence
+
+**Convergence is not formally proven.** The current recursion engine only
+commits to **heuristic termination** based on evaluation metrics and policy
+thresholds. The system does not provide a mathematical convergence proof for
+iterative refinement across all workflows, templates, or evaluation regimes.
+
+Instead, termination is guaranteed by enforced guardrails and explicit policy
+limits. These guardrails are implemented in
+[`ai_recursive/recursion_manager.py`](../ai_recursive/recursion_manager.py) and
+must be treated as the formal assumptions for bounded recursion:
+
+- **Mandatory termination condition:** recursive calls require a
+  `termination_condition`, otherwise the call raises a termination error.
+- **Hard ceilings:** `max_depth` and `max_children` enforce bounded recursion.
+- **Cost budgeting:** `cost_budget` caps cumulative cost for a recursion root.
+- **Checkpoint gating:** `checkpoint_ratio` allows checkpoints to halt progress
+  before limits are exceeded.
+- **Audit trail:** each recursion call records immutable metadata required for
+  provenance and replay.
+
+## Formal assumptions linked to guardrails
+
+The following assumptions are required for the heuristic termination guarantee:
+
+1. **Guardrails are enabled** for any recursion call site that opts into
+   `ai_recursive.RecursionManager`.
+2. **Policy limits are finite** (`max_depth`, `max_children`, `cost_budget`) and
+   enforced without overrides that remove bounds.
+3. **Termination conditions are declared** at the call site and kept in the
+   structured audit trail.
+
+These assumptions map directly to the guardrails in
+[`ai_recursive/recursion_manager.py`](../ai_recursive/recursion_manager.py) and
+should be validated during recursion policy reviews.

--- a/docs/architecture/recursion_engine.md
+++ b/docs/architecture/recursion_engine.md
@@ -18,6 +18,7 @@ Key goals:
 - adjust dependencies to keep the DAG consistent
 
 This behavior is implemented primarily in [`generator/recursion_manager.py`](../../generator/recursion_manager.py) with supporting schemas and evaluation modules referenced in [docs/ARCHITECTURE.md](../ARCHITECTURE.md) and [docs/RECURSION_MANAGER.md](../RECURSION_MANAGER.md).
+The recursion policy (guardrails and termination semantics) is summarized in the root [README](../../README.md), with formal guarantees and assumptions in [docs/FORMAL_GUARANTEES.md](../FORMAL_GUARANTEES.md).
 
 ---
 


### PR DESCRIPTION
### Motivation
- Make explicit whether recursion provides formal convergence guarantees or only heuristic termination and link those claims to implemented guardrails in the codebase.
- Surface the assumptions relied on by the recursion engine so reviewers and auditors can validate policy limits and audit trails.
- Connect documentation to the authoritative guardrails implemented in `ai_recursive/recursion_manager.py` to avoid mismatches between text and behavior.

### Description
- Add `docs/FORMAL_GUARANTEES.md` which states that convergence is not formally proven and enumerates the guardrails (e.g., `max_depth`, `max_children`, `cost_budget`, `checkpoint_ratio`, mandatory `termination_condition`) that bound recursion and serve as formal assumptions.
- Update `README.md` to reference the new `docs/FORMAL_GUARANTEES.md` as the source of formal guarantees and assumptions for recursion policy.
- Update `docs/architecture/recursion_engine.md` to reference `docs/FORMAL_GUARANTEES.md` so architecture notes and implementation are cross-linked to the formal assumptions.

### Testing
- ⚠️ No automated tests were executed for these documentation changes; changes are limited to docs (`docs/FORMAL_GUARANTEES.md`, `README.md`, `docs/architecture/recursion_engine.md`).