### PR TITLE
Add performance benchmark results and raw artifact

### DIFF
--- a/artifacts/performance/benchmarks_20251227_090721.json
+++ b/artifacts/performance/benchmarks_20251227_090721.json
@@ -1,0 +1,62 @@
+{
+  "anchor": {
+    "anchor_id": "performance_benchmark_results",
+    "anchor_version": "1.0.0",
+    "scope": "benchmarking",
+    "owner": "performance_benchmark_script",
+    "status": "draft"
+  },
+  "run": {
+    "timestamp_utc": "2025-12-27T09:07:21Z",
+    "working_directory": "/workspace/SSWG-mvm1.0"
+  },
+  "environment": {
+    "os": "Linux-6.12.13-x86_64-with-glibc2.39",
+    "kernel": "6.12.13",
+    "machine": "x86_64",
+    "cpu_model": "Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz",
+    "cpu_count": 3,
+    "memory_bytes": 19253211136,
+    "python_version": "3.11.12"
+  },
+  "dataset": {
+    "path": "/workspace/SSWG-mvm1.0/pdl/example_full_9_phase.yaml",
+    "bytes": 3678,
+    "lines": 135,
+    "sha256": "452e1190af820d3f9a552a4adc6535e1db7b15694b0d0ede290816c0e06c2acc"
+  },
+  "configuration": {
+    "io_read_iterations": 2000,
+    "io_write_iterations": 500,
+    "phase_iterations": 200,
+    "recursion_iterations": 50
+  },
+  "throughput": {
+    "io_read_mb_s": 557.2960566614081,
+    "io_write_mb_s": 28.56600344708367,
+    "io_read_seconds": 0.012587973999870883,
+    "io_write_seconds": 0.06139490500027023
+  },
+  "phase_timings_seconds": {
+    "normalize_total": 0.00263888900008169,
+    "normalize_avg": 1.319444500040845e-05,
+    "parse_total": 1.6685305320006592,
+    "parse_avg": 0.008342652660003296,
+    "analyze_total": 0.00016536799921595957,
+    "analyze_avg": 8.268399960797978e-07,
+    "generate_total": 0.0012928109999847948,
+    "generate_avg": 6.464054999923974e-06,
+    "validate_total": 1.3269139599997288,
+    "validate_avg": 0.0066345697999986445,
+    "compare_total": 2.333799966436345e-05,
+    "compare_avg": 1.1668999832181725e-07,
+    "interpret_total": 6.682799994450761e-05,
+    "interpret_avg": 3.3413999972253805e-07,
+    "log_total": 0.007980115000464139,
+    "log_avg": 3.9900575002320695e-05
+  },
+  "recursion_timings_seconds": {
+    "total": 0.7292253699997673,
+    "avg_per_iteration": 0.014584507399995346
+  }
+}

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -1,6 +1,76 @@
+---
+anchor:
+  anchor_id: performance_benchmarks_doc
+  anchor_version: 1.0.0
+  scope: docs
+  owner: docs.performance
+  status: draft
+---
+
 # Performance Benchmarks
 
 This document tracks memory usage, recursion time, module reuse, and throughput efficiency across workflow generations. Benchmarks are used to guide optimization, ensure deterministic execution, and evaluate system evolution.
+
+## ✅ Latest Measured Results (2025-12-27T09:07:21Z)
+
+**Raw results:** [`artifacts/performance/benchmarks_20251227_090721.json`](../artifacts/performance/benchmarks_20251227_090721.json)
+
+### Environment Metadata
+
+| Field | Value |
+| --- | --- |
+| OS | Linux-6.12.13-x86_64-with-glibc2.39 |
+| Kernel | 6.12.13 |
+| Machine | x86_64 |
+| CPU | Intel(R) Xeon(R) Platinum 8370C CPU @ 2.80GHz (3 cores available) |
+| Memory | 19,253,211,136 bytes (~17.9 GiB) |
+| Python | 3.11.12 |
+
+### Dataset + Reminder
+
+| Field | Value |
+| --- | --- |
+| Dataset | `pdl/example_full_9_phase.yaml` |
+| Size | 3,678 bytes (135 lines) |
+| SHA-256 | `452e1190af820d3f9a552a4adc6535e1db7b15694b0d0ede290816c0e06c2acc` |
+
+### Run Configuration
+
+| Setting | Value |
+| --- | --- |
+| IO read iterations | 2,000 |
+| IO write iterations | 500 |
+| Phase timing iterations | 200 |
+| Recursion iterations | 50 |
+
+### Throughput (Measured)
+
+| Metric | Value |
+| --- | --- |
+| IO read throughput | 557.30 MB/s |
+| IO write throughput | 28.57 MB/s |
+| IO read elapsed | 0.0126 s |
+| IO write elapsed | 0.0614 s |
+
+### Phase Completion Time (Average per iteration)
+
+| Phase | Average (s) | Total (s) |
+| --- | --- | --- |
+| normalize | 0.00001319 | 0.0026 |
+| parse | 0.00834265 | 1.6685 |
+| analyze | 0.00000083 | 0.0002 |
+| generate | 0.00000646 | 0.0013 |
+| validate | 0.00663457 | 1.3269 |
+| compare | 0.00000012 | 0.0000 |
+| interpret | 0.00000033 | 0.0001 |
+| log | 0.00003990 | 0.0080 |
+
+### Recursion Timing
+
+| Metric | Value |
+| --- | --- |
+| Total recursion time (50 iterations) | 0.7292 s |
+| Average per recursion iteration | 0.0146 s |
 
 ## 🧠 Benchmark Metrics
 


### PR DESCRIPTION
### Motivation

- Provide measured throughput and per-phase timing for the canonical PDL example to inform optimization and capacity planning.
- Persist raw benchmark output for traceability and replayability alongside environment metadata and run configuration.

### Description

- Add anchored documentation section to `docs/PERFORMANCE_BENCHMARKS.md` summarizing measured IO and phase timings and linking the raw output.
- Store raw benchmark JSON at `artifacts/performance/benchmarks_20251227_090721.json` and include dataset metadata (size, sha256, lines).
- Include environment metadata (OS, kernel, CPU, memory, Python) and run configuration (iteration counts) in both the doc and the artifact.

### Testing

- ✅ Ran the ad-hoc benchmark capture script which produced `artifacts/performance/benchmarks_20251227_090721.json` and returned throughput and phase timing data (succeeded).
- ✅ PDL validation was exercised as part of the run via `generator.pdl_validator.validate_pdl_object` and did not raise schema errors.
- ⚠️ No full test-suite (`pytest`) run as part of this change since this PR only adds measurement artifacts and documentation.