### PR TITLE
Add profiling script and store profiling snapshots for mvm workflows

### DIFF
--- a/data/profiling/campfire_workflow/campfire_workflow.json
+++ b/data/profiling/campfire_workflow/campfire_workflow.json
@@ -1,0 +1,275 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Tommy-Raven/SSWG-mvm1.0/main/schemas/workflow_schema.json",
+  "$id": "https://github.com/Tommy-Raven/SSWG-mvm1.0/tree/main/data/templates/campfire_workflow.json",
+  "workflow_id": "campfire_workflow",
+  "version": "0.1.0",
+  "schema_version": "1.0.0",
+  "metadata": {
+    "title": "Build a safe campfire",
+    "description": "Step-by-step workflow to build a small, safe campfire for cooking and warmth.",
+    "author": "Tommy",
+    "created_at": "2025-12-03T00:00:00Z",
+    "domain": "outdoor_survival",
+    "tags": [
+      "campfire",
+      "outdoors",
+      "safety"
+    ]
+  },
+  "phases": [
+    {
+      "phase_id": "phase_1",
+      "name": "Preparation",
+      "description": "Select location, collect permits, check fire danger, gather materials"
+    },
+    {
+      "phase_id": "phase_2",
+      "name": "Construction",
+      "description": "Lay tinder, kindling, fuel wood; form fire structure"
+    },
+    {
+      "phase_id": "phase_3",
+      "name": "Ignition & Management",
+      "description": "Ignite, maintain, and manage burn"
+    },
+    {
+      "phase_id": "phase_4",
+      "name": "Extinguish & Leave No Trace",
+      "description": "Douse and clean site"
+    }
+  ],
+  "modules": [
+    {
+      "module_id": "m01_location_check",
+      "phase_id": "phase_1",
+      "name": "Location & Permits",
+      "inputs": [],
+      "outputs": [
+        "site_approved"
+      ],
+      "dependencies": [],
+      "ai_logic": "Check local regulations, assess proximity to vegetation, evaluate wind conditions.",
+      "human_actionable": "Inspect site. If no local ban and a 10 ft cleared area exists, mark site_approved = true."
+    },
+    {
+      "module_id": "m02_materials_gather",
+      "phase_id": "phase_1",
+      "name": "Gather materials",
+      "inputs": [],
+      "outputs": [
+        "tinder_set",
+        "kindling_set",
+        "fuelwood_set"
+      ],
+      "dependencies": [
+        "m01_location_check"
+      ],
+      "ai_logic": "List locally available tinder, kindling, and fuelwood types and quantities.",
+      "human_actionable": "Collect dry tinder (leaves, birch bark), kindling (small sticks), and fuel wood (split logs)."
+    },
+    {
+      "module_id": "m03_build_structure",
+      "phase_id": "phase_2",
+      "name": "Build fire structure",
+      "inputs": [
+        "tinder_set",
+        "kindling_set"
+      ],
+      "outputs": [
+        "structure_ready"
+      ],
+      "dependencies": [
+        "m02_materials_gather"
+      ],
+      "ai_logic": "Recommend a structure (teepee, log cabin) based on available materials.",
+      "human_actionable": "Construct a small teepee of kindling over tinder, leaving airflow paths."
+    },
+    {
+      "module_id": "m04_ignite",
+      "phase_id": "phase_3",
+      "name": "Ignition",
+      "inputs": [
+        "structure_ready"
+      ],
+      "outputs": [
+        "fire_lit"
+      ],
+      "dependencies": [
+        "m03_build_structure"
+      ],
+      "ai_logic": "Provide step sequence for safe ignition (sparks, matches, lighter), monitor smoldering risk.",
+      "human_actionable": "Ignite tinder carefully; feed small kindling until sustained flame."
+    },
+    {
+      "module_id": "m05_manage",
+      "phase_id": "phase_3",
+      "name": "Manage burn",
+      "inputs": [
+        "fire_lit"
+      ],
+      "outputs": [
+        "burn_controlled"
+      ],
+      "dependencies": [
+        "m04_ignite"
+      ],
+      "ai_logic": "Advise on safe adding of fuel wood, monitor wind changes, advise extinguishing if unsafe.",
+      "human_actionable": "Add fuel wood gradually, maintain a small, controlled flame."
+    },
+    {
+      "module_id": "m06_extinguish",
+      "phase_id": "phase_4",
+      "name": "Extinguish",
+      "inputs": [
+        "burn_controlled"
+      ],
+      "outputs": [
+        "site_clean"
+      ],
+      "dependencies": [
+        "m05_manage"
+      ],
+      "ai_logic": "Provide steps to fully extinguish (soak, stir, feel for heat) and restore site.",
+      "human_actionable": "Douse with water, stir ashes, ensure cold-to-touch, scatter cooled rocks, fill any holes."
+    }
+  ],
+  "outputs": [
+    "site_clean",
+    "process_log.json"
+  ],
+  "evaluation": {
+    "clarity": null,
+    "coverage": null,
+    "feasibility": null,
+    "alignment": null,
+    "notes": [],
+    "quality": {
+      "overall_score": 0.5387210884353741,
+      "metrics": {
+        "clarity": 0.65,
+        "coverage": 1.0,
+        "coherence": 1.0,
+        "completeness": 0.0,
+        "intent_alignment": 1.0,
+        "specificity": 0.12104761904761906,
+        "usability": 0.0
+      }
+    },
+    "meta_metrics": {
+      "timestamp": "2025-12-27T09:09:12.495308+00:00",
+      "scores": {
+        "clarity": 0.65,
+        "coverage": 1.0,
+        "coherence": 1.0,
+        "completeness": 0.0,
+        "intent_alignment": 1.0,
+        "specificity": 0.12104761904761906,
+        "usability": 0.0
+      },
+      "overall_score": 0.5387210884353741,
+      "baseline": {
+        "status": "missing",
+        "overall_score": null,
+        "scores": null
+      },
+      "deltas": {
+        "overall_score": null,
+        "metrics": {}
+      },
+      "thresholds": {
+        "promotion_threshold": 0.02,
+        "regression_guard": -0.05,
+        "guard_metrics": [
+          "clarity",
+          "coherence",
+          "completeness",
+          "intent_alignment",
+          "usability"
+        ]
+      },
+      "decision": {
+        "promotion_eligible": false,
+        "regression_guard_passed": true
+      },
+      "evidence_notes": [
+        "Core metrics computed on the current workflow snapshot.",
+        "Baseline compared against latest stored workflow version."
+      ]
+    }
+  },
+  "recursion": {
+    "max_iterations": 2,
+    "auto_refine": true,
+    "require_human_approval": false
+  },
+  "dependency_graph": {
+    "nodes": [
+      "m01_location_check",
+      "m02_materials_gather",
+      "m03_build_structure",
+      "m04_ignite",
+      "m05_manage",
+      "m06_extinguish"
+    ],
+    "edges": [
+      [
+        "m01_location_check",
+        "m02_materials_gather"
+      ],
+      [
+        "m02_materials_gather",
+        "m03_build_structure"
+      ],
+      [
+        "m03_build_structure",
+        "m04_ignite"
+      ],
+      [
+        "m04_ignite",
+        "m05_manage"
+      ],
+      [
+        "m05_manage",
+        "m06_extinguish"
+      ]
+    ]
+  },
+  "dependency_index": {
+    "upstream": {
+      "m01_location_check": [],
+      "m02_materials_gather": [
+        "m01_location_check"
+      ],
+      "m03_build_structure": [
+        "m02_materials_gather"
+      ],
+      "m04_ignite": [
+        "m03_build_structure"
+      ],
+      "m05_manage": [
+        "m04_ignite"
+      ],
+      "m06_extinguish": [
+        "m05_manage"
+      ]
+    },
+    "downstream": {
+      "m03_build_structure": [
+        "m04_ignite"
+      ],
+      "m06_extinguish": [],
+      "m04_ignite": [
+        "m05_manage"
+      ],
+      "m02_materials_gather": [
+        "m03_build_structure"
+      ],
+      "m01_location_check": [
+        "m02_materials_gather"
+      ],
+      "m05_manage": [
+        "m06_extinguish"
+      ]
+    }
+  }
+}

--- a/data/profiling/campfire_workflow/campfire_workflow.json.anchor.json
+++ b/data/profiling/campfire_workflow/campfire_workflow.json.anchor.json
@@ -1,0 +1,8 @@
+{
+  "anchor_id": "profiling_artifact",
+  "anchor_version": "1.0",
+  "scope": "profiling",
+  "owner": "scripts.profile_workflows",
+  "status": "draft",
+  "artifact_path": "data/profiling/campfire_workflow/campfire_workflow.json"
+}

--- a/data/profiling/campfire_workflow/campfire_workflow.md
+++ b/data/profiling/campfire_workflow/campfire_workflow.md
@@ -1,0 +1,26 @@
+# Workflow campfire_workflow
+
+**Workflow ID:** `campfire_workflow`
+
+## Phases
+### Preparation
+### Construction
+### Ignition & Management
+### Extinguish & Leave No Trace
+
+## Modules
+- {'module_id': 'm01_location_check', 'phase_id': 'phase_1', 'name': 'Location & Permits', 'inputs': [], 'outputs': ['site_approved'], 'dependencies': [], 'ai_logic': 'Check local regulations, assess proximity to vegetation, evaluate wind conditions.', 'human_actionable': 'Inspect site. If no local ban and a 10 ft cleared area exists, mark site_approved = true.'}
+- {'module_id': 'm02_materials_gather', 'phase_id': 'phase_1', 'name': 'Gather materials', 'inputs': [], 'outputs': ['tinder_set', 'kindling_set', 'fuelwood_set'], 'dependencies': ['m01_location_check'], 'ai_logic': 'List locally available tinder, kindling, and fuelwood types and quantities.', 'human_actionable': 'Collect dry tinder (leaves, birch bark), kindling (small sticks), and fuel wood (split logs).'}
+- {'module_id': 'm03_build_structure', 'phase_id': 'phase_2', 'name': 'Build fire structure', 'inputs': ['tinder_set', 'kindling_set'], 'outputs': ['structure_ready'], 'dependencies': ['m02_materials_gather'], 'ai_logic': 'Recommend a structure (teepee, log cabin) based on available materials.', 'human_actionable': 'Construct a small teepee of kindling over tinder, leaving airflow paths.'}
+- {'module_id': 'm04_ignite', 'phase_id': 'phase_3', 'name': 'Ignition', 'inputs': ['structure_ready'], 'outputs': ['fire_lit'], 'dependencies': ['m03_build_structure'], 'ai_logic': 'Provide step sequence for safe ignition (sparks, matches, lighter), monitor smoldering risk.', 'human_actionable': 'Ignite tinder carefully; feed small kindling until sustained flame.'}
+- {'module_id': 'm05_manage', 'phase_id': 'phase_3', 'name': 'Manage burn', 'inputs': ['fire_lit'], 'outputs': ['burn_controlled'], 'dependencies': ['m04_ignite'], 'ai_logic': 'Advise on safe adding of fuel wood, monitor wind changes, advise extinguishing if unsafe.', 'human_actionable': 'Add fuel wood gradually, maintain a small, controlled flame.'}
+- {'module_id': 'm06_extinguish', 'phase_id': 'phase_4', 'name': 'Extinguish', 'inputs': ['burn_controlled'], 'outputs': ['site_clean'], 'dependencies': ['m05_manage'], 'ai_logic': 'Provide steps to fully extinguish (soak, stir, feel for heat) and restore site.', 'human_actionable': 'Douse with water, stir ashes, ensure cold-to-touch, scatter cooled rocks, fill any holes.'}
+
+## Evaluation
+- **clarity**: None
+- **coverage**: None
+- **feasibility**: None
+- **alignment**: None
+- **notes**: []
+- **quality**: {'overall_score': 0.5387210884353741, 'metrics': {'clarity': 0.65, 'coverage': 1.0, 'coherence': 1.0, 'completeness': 0.0, 'intent_alignment': 1.0, 'specificity': 0.12104761904761906, 'usability': 0.0}}
+- **meta_metrics**: {'timestamp': '2025-12-27T09:09:12.495308+00:00', 'scores': {'clarity': 0.65, 'coverage': 1.0, 'coherence': 1.0, 'completeness': 0.0, 'intent_alignment': 1.0, 'specificity': 0.12104761904761906, 'usability': 0.0}, 'overall_score': 0.5387210884353741, 'baseline': {'status': 'missing', 'overall_score': None, 'scores': None}, 'deltas': {'overall_score': None, 'metrics': {}}, 'thresholds': {'promotion_threshold': 0.02, 'regression_guard': -0.05, 'guard_metrics': ['clarity', 'coherence', 'completeness', 'intent_alignment', 'usability']}, 'decision': {'promotion_eligible': False, 'regression_guard_passed': True}, 'evidence_notes': ['Core metrics computed on the current workflow snapshot.', 'Baseline compared against latest stored workflow version.']}

--- a/data/profiling/campfire_workflow/campfire_workflow.md.anchor.json
+++ b/data/profiling/campfire_workflow/campfire_workflow.md.anchor.json
@@ -1,0 +1,8 @@
+{
+  "anchor_id": "profiling_artifact",
+  "anchor_version": "1.0",
+  "scope": "profiling",
+  "owner": "scripts.profile_workflows",
+  "status": "draft",
+  "artifact_path": "data/profiling/campfire_workflow/campfire_workflow.md"
+}

--- a/data/profiling/technical_procedure_template/unnamed_workflow.json
+++ b/data/profiling/technical_procedure_template/unnamed_workflow.json
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://raw.githubusercontent.com/Tommy-Raven/SSWG-mvm1.0/main/schemas/template_schema.json",
+  "$id": "https://github.com/Tommy-Raven/SSWG-mvm1.0/tree/main/data/templates/technical_procedure_template.json",
+  "template_id": "technical_procedure",
+  "title": "Technical Procedure Workflow Blueprint",
+  "description": "Outlines a process for designing, verifying, and documenting a reproducible technical operation or engineering process.",
+  "phases": [
+    {
+      "id": "P1",
+      "title": "Specification and Scope Definition",
+      "tasks": [
+        "Clarify operational objectives and constraints",
+        "Gather system requirements and environmental parameters",
+        "Determine necessary tools, materials, and personnel"
+      ]
+    },
+    {
+      "id": "P2",
+      "title": "Procedure Drafting and Sequencing",
+      "tasks": [
+        "Draft step-by-step operational instructions",
+        "Sequence dependencies logically and ensure safety compliance",
+        "Include fallback procedures for potential failure states"
+      ]
+    },
+    {
+      "id": "P3",
+      "title": "Testing, Validation, and Documentation",
+      "tasks": [
+        "Run pilot tests and record observations",
+        "Validate each step against technical specifications",
+        "Finalize procedural document and archive results"
+      ]
+    }
+  ],
+  "metadata": {
+    "category": "Engineering",
+    "author": "Grimoire v4.5",
+    "version": "1.0"
+  },
+  "dependency_graph": {
+    "nodes": [],
+    "edges": []
+  },
+  "dependency_index": {
+    "upstream": {},
+    "downstream": {}
+  },
+  "evaluation": {
+    "quality": {
+      "overall_score": 0.21685714285714286,
+      "metrics": {
+        "clarity": 0.0,
+        "coverage": 0.0,
+        "coherence": 1.0,
+        "completeness": 0.5,
+        "intent_alignment": 0.0,
+        "specificity": 0.018,
+        "usability": 0.0
+      }
+    },
+    "meta_metrics": {
+      "timestamp": "2025-12-27T09:09:12.579353+00:00",
+      "scores": {
+        "clarity": 0.0,
+        "coverage": 0.0,
+        "coherence": 1.0,
+        "completeness": 0.5,
+        "intent_alignment": 0.0,
+        "specificity": 0.018,
+        "usability": 0.0
+      },
+      "overall_score": 0.21685714285714286,
+      "baseline": {
+        "status": "missing",
+        "overall_score": null,
+        "scores": null
+      },
+      "deltas": {
+        "overall_score": null,
+        "metrics": {}
+      },
+      "thresholds": {
+        "promotion_threshold": 0.02,
+        "regression_guard": -0.05,
+        "guard_metrics": [
+          "clarity",
+          "coherence",
+          "completeness",
+          "intent_alignment",
+          "usability"
+        ]
+      },
+      "decision": {
+        "promotion_eligible": false,
+        "regression_guard_passed": true
+      },
+      "evidence_notes": [
+        "Core metrics computed on the current workflow snapshot.",
+        "Baseline compared against latest stored workflow version."
+      ]
+    }
+  }
+}

--- a/data/profiling/technical_procedure_template/unnamed_workflow.json.anchor.json
+++ b/data/profiling/technical_procedure_template/unnamed_workflow.json.anchor.json
@@ -1,0 +1,8 @@
+{
+  "anchor_id": "profiling_artifact",
+  "anchor_version": "1.0",
+  "scope": "profiling",
+  "owner": "scripts.profile_workflows",
+  "status": "draft",
+  "artifact_path": "data/profiling/technical_procedure_template/unnamed_workflow.json"
+}

--- a/data/profiling/technical_procedure_template/unnamed_workflow.md
+++ b/data/profiling/technical_procedure_template/unnamed_workflow.md
@@ -1,0 +1,23 @@
+# Technical Procedure Workflow Blueprint
+
+**Workflow ID:** `unnamed_workflow`
+
+**Objective:** Outlines a process for designing, verifying, and documenting a reproducible technical operation or engineering process.
+
+## Phases
+### P1
+- Clarify operational objectives and constraints
+- Gather system requirements and environmental parameters
+- Determine necessary tools, materials, and personnel
+### P2
+- Draft step-by-step operational instructions
+- Sequence dependencies logically and ensure safety compliance
+- Include fallback procedures for potential failure states
+### P3
+- Run pilot tests and record observations
+- Validate each step against technical specifications
+- Finalize procedural document and archive results
+
+## Evaluation
+- **quality**: {'overall_score': 0.21685714285714286, 'metrics': {'clarity': 0.0, 'coverage': 0.0, 'coherence': 1.0, 'completeness': 0.5, 'intent_alignment': 0.0, 'specificity': 0.018, 'usability': 0.0}}
+- **meta_metrics**: {'timestamp': '2025-12-27T09:09:12.579353+00:00', 'scores': {'clarity': 0.0, 'coverage': 0.0, 'coherence': 1.0, 'completeness': 0.5, 'intent_alignment': 0.0, 'specificity': 0.018, 'usability': 0.0}, 'overall_score': 0.21685714285714286, 'baseline': {'status': 'missing', 'overall_score': None, 'scores': None}, 'deltas': {'overall_score': None, 'metrics': {}}, 'thresholds': {'promotion_threshold': 0.02, 'regression_guard': -0.05, 'guard_metrics': ['clarity', 'coherence', 'completeness', 'intent_alignment', 'usability']}, 'decision': {'promotion_eligible': False, 'regression_guard_passed': True}, 'evidence_notes': ['Core metrics computed on the current workflow snapshot.', 'Baseline compared against latest stored workflow version.']}

--- a/data/profiling/technical_procedure_template/unnamed_workflow.md.anchor.json
+++ b/data/profiling/technical_procedure_template/unnamed_workflow.md.anchor.json
@@ -1,0 +1,8 @@
+{
+  "anchor_id": "profiling_artifact",
+  "anchor_version": "1.0",
+  "scope": "profiling",
+  "owner": "scripts.profile_workflows",
+  "status": "draft",
+  "artifact_path": "data/profiling/technical_procedure_template/unnamed_workflow.md"
+}

--- a/data/profiling/workflow_profiling_2025-12-27.json
+++ b/data/profiling/workflow_profiling_2025-12-27.json
@@ -1,0 +1,150 @@
+{
+  "anchor": {
+    "anchor_id": "performance_profiling_snapshot",
+    "anchor_version": "1.0",
+    "scope": "profiling",
+    "owner": "scripts.profile_workflows",
+    "status": "draft"
+  },
+  "timestamp_utc": "2025-12-27T09:09:12.405379+00:00",
+  "environment": {
+    "python_version": "3.11.12",
+    "platform": "Linux-6.12.13-x86_64-with-glibc2.39"
+  },
+  "workloads": [
+    {
+      "workflow_path": "data/templates/campfire_workflow.json",
+      "workflow_id": "campfire_workflow",
+      "phases": {
+        "load_workflow": {
+          "duration_sec": 0.0006994900004428928,
+          "memory_current_kib": 11.4599609375,
+          "memory_peak_kib": 16.37890625
+        },
+        "normalize_task_packaging": {
+          "duration_sec": 9.857999430096243e-06,
+          "memory_current_kib": 0.0,
+          "memory_peak_kib": 0.046875
+        },
+        "inheritance_checks": {
+          "duration_sec": 6.985999789321795e-06,
+          "memory_current_kib": 0.0,
+          "memory_peak_kib": 0.1171875
+        },
+        "schema_validation": {
+          "duration_sec": 0.07824746799997229,
+          "memory_current_kib": 627.712890625,
+          "memory_peak_kib": 855.271484375,
+          "details": {
+            "ok": false,
+            "error_count": 0,
+            "exception": "<urlopen error Tunnel connection failed: 403 Forbidden>"
+          }
+        },
+        "dependency_graph": {
+          "duration_sec": 0.0013248420000309125,
+          "memory_current_kib": 1.6171875,
+          "memory_peak_kib": 5.9765625
+        },
+        "mermaid_render": {
+          "duration_sec": 3.809500049101189e-05,
+          "memory_current_kib": 0.4560546875,
+          "memory_peak_kib": 1.4931640625,
+          "details": {
+            "mermaid_length": 418
+          }
+        },
+        "evaluation_scoring": {
+          "duration_sec": 0.0013348229995244765,
+          "memory_current_kib": 0.40625,
+          "memory_peak_kib": 16.6416015625,
+          "details": {
+            "overall_score": 0.5387210884353741
+          }
+        },
+        "meta_metrics": {
+          "duration_sec": 0.0004424460003065178,
+          "memory_current_kib": 7.64453125,
+          "memory_peak_kib": 8.8818359375
+        },
+        "export_artifacts": {
+          "duration_sec": 0.004237729000124091,
+          "memory_current_kib": 8.1025390625,
+          "memory_peak_kib": 48.4892578125
+        }
+      },
+      "totals": {
+        "duration_sec": 0.0863417370001116,
+        "peak_memory_kib": 855.271484375
+      },
+      "name": "campfire_workflow"
+    },
+    {
+      "workflow_path": "data/templates/technical_procedure_template.json",
+      "workflow_id": null,
+      "phases": {
+        "load_workflow": {
+          "duration_sec": 0.0003071179999096785,
+          "memory_current_kib": 3.1728515625,
+          "memory_peak_kib": 7.8935546875
+        },
+        "normalize_task_packaging": {
+          "duration_sec": 1.2782999874616507e-05,
+          "memory_current_kib": 0.09375,
+          "memory_peak_kib": 0.1875
+        },
+        "inheritance_checks": {
+          "duration_sec": 4.998999429517426e-06,
+          "memory_current_kib": 0.046875,
+          "memory_peak_kib": 0.1171875
+        },
+        "schema_validation": {
+          "duration_sec": 0.07811084399963875,
+          "memory_current_kib": 91.462890625,
+          "memory_peak_kib": 145.880859375,
+          "details": {
+            "ok": false,
+            "error_count": 13,
+            "exception": null
+          }
+        },
+        "dependency_graph": {
+          "duration_sec": 0.00028105300043534953,
+          "memory_current_kib": 0.2265625,
+          "memory_peak_kib": 3.53125
+        },
+        "mermaid_render": {
+          "duration_sec": 6.524999662360642e-06,
+          "memory_current_kib": 0.0234375,
+          "memory_peak_kib": 0.0546875,
+          "details": {
+            "mermaid_length": 12
+          }
+        },
+        "evaluation_scoring": {
+          "duration_sec": 0.0001921519997267751,
+          "memory_current_kib": 0.390625,
+          "memory_peak_kib": 1.587890625,
+          "details": {
+            "overall_score": 0.21685714285714286
+          }
+        },
+        "meta_metrics": {
+          "duration_sec": 0.00032097199982672464,
+          "memory_current_kib": 0.7841796875,
+          "memory_peak_kib": 1.642578125
+        },
+        "export_artifacts": {
+          "duration_sec": 0.0027081130001533893,
+          "memory_current_kib": 3.3544921875,
+          "memory_peak_kib": 24.5927734375
+        }
+      },
+      "totals": {
+        "duration_sec": 0.08194455899865716,
+        "peak_memory_kib": 145.880859375
+      },
+      "name": "technical_procedure_template"
+    }
+  ]
+}

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -21,6 +21,26 @@ This document tracks memory usage, recursion time, module reuse, and throughput 
 * CLI dashboard and visualization tools display performance trends.
 * Metrics support adaptive optimization, such as caching strategies, async execution, and semantic delta stopping.
 
+## 📌 Profiling Snapshots (2025-12-27)
+
+**Methodology**
+
+* Workloads: `campfire_workflow.json` and `technical_procedure_template.json` from `data/templates/`.
+* Phases measured: load workflow, normalize task packaging, inheritance checks, schema validation, dependency graph build, mermaid render, evaluation scoring, meta metrics, and export artifacts.
+* Timing: `time.perf_counter()` per phase.
+* Memory: `tracemalloc` per phase (reported in KiB; captures Python allocation peaks).
+* Schema validation attempts may include remote `$ref` resolution; the snapshot records any validation exception text.
+
+**Artifacts**
+
+* Snapshot JSON: [`data/profiling/workflow_profiling_2025-12-27.json`](../data/profiling/workflow_profiling_2025-12-27.json)
+* Campfire outputs:
+  * [`data/profiling/campfire_workflow/campfire_workflow.json`](../data/profiling/campfire_workflow/campfire_workflow.json)
+  * [`data/profiling/campfire_workflow/campfire_workflow.md`](../data/profiling/campfire_workflow/campfire_workflow.md)
+* Technical procedure outputs:
+  * [`data/profiling/technical_procedure_template/unnamed_workflow.json`](../data/profiling/technical_procedure_template/unnamed_workflow.json)
+  * [`data/profiling/technical_procedure_template/unnamed_workflow.md`](../data/profiling/technical_procedure_template/unnamed_workflow.md)
+
 ## ⚡ Optimization Integration
 
 * Core stability and exception handling minimize runtime errors and infinite loops.

--- a/scripts/profile_workflows.py
+++ b/scripts/profile_workflows.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+Collect per-phase timing + memory profiling snapshots for mvm workflows.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import sys
+import time
+import tracemalloc
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Tuple
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from ai_evaluation.evaluation_engine import evaluate_workflow_quality
+from ai_monitoring.structured_logger import log_event
+from ai_validation.schema_validator import validate_workflow
+from ai_visualization.mermaid_generator import mermaid_from_workflow
+from generator import main as mvm_main
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _measure_phase(
+    label: str,
+    func: Callable[[], Any],
+) -> Tuple[Any, Dict[str, Any]]:
+    tracemalloc.start()
+    start = time.perf_counter()
+    result = func()
+    duration = time.perf_counter() - start
+    current, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    snapshot = {
+        "duration_sec": duration,
+        "memory_current_kib": current / 1024.0,
+        "memory_peak_kib": peak / 1024.0,
+    }
+    return result, snapshot
+
+
+def _summarize_total(phases: Dict[str, Dict[str, Any]]) -> Dict[str, float]:
+    total_duration = sum(phase["duration_sec"] for phase in phases.values())
+    peak_memory = max(
+        (phase["memory_peak_kib"] for phase in phases.values()),
+        default=0.0,
+    )
+    return {
+        "duration_sec": total_duration,
+        "peak_memory_kib": peak_memory,
+    }
+
+
+def _safe_validate_workflow(workflow: Dict[str, Any]) -> Tuple[bool, list[str], str | None]:
+    try:
+        ok, errors = validate_workflow(workflow)
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        return False, [], str(exc)
+    return bool(ok), [str(error) for error in (errors or [])], None
+
+
+def _write_anchor(artifact_path: Path) -> Path:
+    anchor_path = Path(f"{artifact_path}.anchor.json")
+    anchor = {
+        "anchor_id": "profiling_artifact",
+        "anchor_version": "1.0",
+        "scope": "profiling",
+        "owner": "scripts.profile_workflows",
+        "status": "draft",
+        "artifact_path": str(artifact_path),
+    }
+    anchor_path.write_text(json.dumps(anchor, indent=2), encoding="utf-8")
+    return anchor_path
+
+
+def profile_workflow(workflow_path: Path, *, out_dir: Path) -> Dict[str, Any]:
+    phases: Dict[str, Dict[str, Any]] = {}
+
+    workflow, phases["load_workflow"] = _measure_phase(
+        "load_workflow", lambda: mvm_main.load_workflow(workflow_path)
+    )
+    workflow = deepcopy(workflow)
+
+    _, phases["normalize_task_packaging"] = _measure_phase(
+        "normalize_task_packaging",
+        lambda: mvm_main._apply_task_packaging(
+            workflow, change_source="profiling_run"
+        ),
+    )
+
+    _, phases["inheritance_checks"] = _measure_phase(
+        "inheritance_checks",
+        lambda: mvm_main._apply_inheritance_checks(
+            workflow, change_source="profiling_run"
+        ),
+    )
+
+    (schema_ok, schema_errors, schema_exception), phases["schema_validation"] = _measure_phase(
+        "schema_validation",
+        lambda: _safe_validate_workflow(workflow),
+    )
+    phases["schema_validation"]["details"] = {
+        "ok": bool(schema_ok),
+        "error_count": len(schema_errors or []),
+        "exception": schema_exception,
+    }
+
+    _, phases["dependency_graph"] = _measure_phase(
+        "dependency_graph",
+        lambda: mvm_main._apply_dependency_tracking(
+            workflow, change_source="profiling_run"
+        ),
+    )
+
+    mermaid, phases["mermaid_render"] = _measure_phase(
+        "mermaid_render",
+        lambda: mermaid_from_workflow(workflow),
+    )
+    phases["mermaid_render"]["details"] = {
+        "mermaid_length": len(mermaid or ""),
+    }
+
+    quality, phases["evaluation_scoring"] = _measure_phase(
+        "evaluation_scoring",
+        lambda: evaluate_workflow_quality(workflow),
+    )
+    phases["evaluation_scoring"]["details"] = {
+        "overall_score": quality.get("overall_score", 0.0),
+    }
+
+    workflow.setdefault("evaluation", {})["quality"] = quality
+    _, phases["meta_metrics"] = _measure_phase(
+        "meta_metrics",
+        lambda: mvm_main._apply_meta_metrics(workflow, quality_report=quality),
+    )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    artifacts, phases["export_artifacts"] = _measure_phase(
+        "export_artifacts",
+        lambda: mvm_main.export_artifacts(workflow, out_dir),
+    )
+    anchor_paths = []
+    for artifact_path in (artifacts or {}).values():
+        anchor_paths.append(_write_anchor(Path(artifact_path)))
+    phases["export_artifacts"]["details"] = {
+        "artifacts": artifacts or {},
+        "anchors": [str(path) for path in anchor_paths],
+    }
+
+    return {
+        "workflow_path": str(workflow_path),
+        "workflow_id": workflow.get("workflow_id"),
+        "phases": phases,
+        "totals": _summarize_total(phases),
+    }
+
+
+def build_snapshot(workflows: list[Path], *, out_dir: Path) -> Dict[str, Any]:
+    snapshot = {
+        "anchor": {
+            "anchor_id": "performance_profiling_snapshot",
+            "anchor_version": "1.0",
+            "scope": "profiling",
+            "owner": "scripts.profile_workflows",
+            "status": "draft",
+        },
+        "timestamp_utc": _timestamp(),
+        "environment": {
+            "python_version": platform.python_version(),
+            "platform": platform.platform(),
+        },
+        "workloads": [],
+    }
+
+    for workflow_path in workflows:
+        workload_name = workflow_path.stem
+        workload_out_dir = out_dir / workload_name
+        workload_snapshot = profile_workflow(workflow_path, out_dir=workload_out_dir)
+        workload_snapshot["name"] = workload_name
+        snapshot["workloads"].append(workload_snapshot)
+
+    return snapshot
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Profile mvm workflow phases for timing + memory snapshots.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("data/profiling"),
+        help="Directory to store profiling snapshots.",
+    )
+    parser.add_argument(
+        "--templates",
+        nargs="+",
+        default=[
+            "data/templates/campfire_workflow.json",
+            "data/templates/technical_procedure_template.json",
+        ],
+        help="Workflow template JSON paths to profile.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    workflows = [Path(path) for path in args.templates]
+    snapshot = build_snapshot(workflows, out_dir=args.output_dir)
+
+    date_slug = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    output_path = args.output_dir / f"workflow_profiling_{date_slug}.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+
+    log_event(
+        "profiling.snapshot_written",
+        {"path": str(output_path), "workloads": len(snapshot["workloads"])},
+    )
+    print(f"Wrote profiling snapshot to {output_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation

- Capture per-phase timing and memory usage for representative mvm workloads to identify performance bottlenecks and guide optimizations.
- Persist raw profiling outputs and canonical anchor sidecars so artifacts are auditable and replayable.
- Record schema validation failures (including remote `$ref` resolution errors) in the snapshot so validation behavior is visible during profiling.
- Surface profiling methodology in documentation to make results reproducible and discoverable.

### Description

- Add `scripts/profile_workflows.py`, a profiling tool that measures per-phase duration with `time.perf_counter()` and memory with `tracemalloc`, builds a snapshot JSON, and writes it to `data/profiling`.
- Introduce a safe validation wrapper that captures exceptions from `validate_workflow` and records exception text in the `schema_validation` phase details.
- Persist exported workflow artifacts and companion anchor sidecars (`*.anchor.json`) under `data/profiling/<workload>/` for auditability.
- Update `docs/PERFORMANCE_BENCHMARKS.md` with the profiling methodology and links to the generated snapshot and artifact files.

### Testing

- ✅ `python scripts/profile_workflows.py` — executed successfully and wrote `data/profiling/workflow_profiling_2025-12-27.json` along with workload artifacts under `data/profiling/`.
- ✅ Verified that per-phase timing and memory fields are present in the snapshot and that schema validation exceptions (when triggered) are recorded in the snapshot details.
- ✅ Confirmed anchor sidecar files were created next to exported artifacts for both profiled workloads.
