### PR TITLE
Add formal recursion correctness proofs

### DIFF
--- a/ai_recursive/__init__.py
+++ b/ai_recursive/__init__.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 from .variant_generator import generate_variants
 from .merge_engine import merge_variants
 from .recursion_manager import (
+    ProofStep,
+    RecursionProof,
     RecursionBudgetError,
     RecursionCheckpointError,
     RecursionLimitError,
@@ -32,6 +34,8 @@ __all__ = [
     "merge_variants",
     "RecursionManager",
     "RecursionSnapshot",
+    "RecursionProof",
+    "ProofStep",
     "RecursionLimitError",
     "RecursionBudgetError",
     "RecursionCheckpointError",

--- a/tests/test_recursion_proofs.py
+++ b/tests/test_recursion_proofs.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Tests for recursion correctness proofs."""
+
+from ai_recursive import RecursionManager
+
+
+def test_recursion_proof_success():
+    manager = RecursionManager(max_depth=3, max_children=5, cost_budget=10.0)
+    manager.prepare_call(
+        root_id="root",
+        parent_id=None,
+        depth=1,
+        estimated_cost=2.0,
+        termination_condition="depth",
+    )
+    manager.prepare_call(
+        root_id="root",
+        parent_id="root",
+        depth=2,
+        estimated_cost=1.0,
+        termination_condition="budget",
+    )
+
+    proof = manager.prove_correctness("root")
+
+    assert proof.overall_ok is True
+    assert proof.steps
+    assert all(step.ok for step in proof.steps)
+
+
+def test_recursion_proof_missing_audit_log():
+    manager = RecursionManager()
+    proof = manager.prove_correctness("missing-root")
+
+    assert proof.overall_ok is False
+    assert proof.steps[0].ok is False


### PR DESCRIPTION
### Motivation
- Provide machine-verifiable correctness checks for the recursive refinement guardrails in the `ai_recursive` subsystem to satisfy MVM termination and audit requirements.
- Improve auditability and make invariants (depth, child caps, cost budgets, and termination conditions) explicit and checkable after runs.
- Surface deterministic proof artifacts that can be used by validation and higher-level tooling.

### Description
- Add `ProofStep` and `RecursionProof` dataclasses to `ai_recursive/recursion_manager.py` to represent proof elements and overall proof results.
- Implement `RecursionManager.prove_correctness(root_id)` which verifies depth bounds, child sequencing and caps, cost monotonicity and budget adherence, presence of termination conditions, and budget consistency.
- Export `ProofStep` and `RecursionProof` from the `ai_recursive` package via `ai_recursive/__init__.py`.
- Add `tests/test_recursion_proofs.py` with cases for a successful proof and a missing-audit-log failure.

### Testing
- ✅ `pytest -q tests/test_recursion_proofs.py` — passed (`2 passed`).
- All newly added tests passed locally and validate the proof-generation behavior for the `RecursionManager`.
