### PR TITLE
Fix test_config docstring parsing error

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 """
-conftest.py — SSWG–MVM Global Test Fixtures
+test_config.py — SSWG–MVM Config Tests
 """
 
 import json
@@ -52,8 +52,8 @@ def output_dir(tmp_path_factory):
 @pytest.fixture(scope="session")
 def template_dir():
     return Path("data/templates").absolute()
-Tests configuration loading + template resolution.
-"""
+
+# Tests configuration loading + template resolution.
 
 from data.data_parsing import load_template
 


### PR DESCRIPTION
### Motivation
- The test module `tests/test_config.py` contained an unterminated triple-quoted string which raised a `SyntaxError` during pytest collection.
- This prevented test discovery and blocked CI validation of configuration-related tests.

### Description
- Corrected the module docstring header in `tests/test_config.py` and converted the stray multiline comment into a proper single-line comment to restore syntactic validity.
- No functional changes to fixtures or test logic were made beyond making the file importable.
- Modified file: `tests/test_config.py`.

### Testing
- ✅ Ran `pytest tests/test_config.py` and it completed successfully with `1 passed`.
- ✅ Confirmed the test file imports without syntax errors during collection by running the test run above.