### PR TITLE
Update contributor governance documentation (DCO, CoC, Security)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,53 @@
+---
+anchor:
+  anchor_id: code_of_conduct
+  anchor_version: "1.0.0"
+  scope: governance
+  owner: sswg
+  status: draft
+---
+
 # Code of Conduct
 
-Placeholder content: The SSWG/MVM code of conduct will be published here. Until then, contributors must follow the repository governance and compliance requirements defined in the root AGENTS.md.
+## Our pledge
+
+We are committed to providing a welcoming, safe, and professional environment
+for everyone participating in the sswg/mvm project, regardless of background,
+identity, or experience.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Treating others with respect, empathy, and professionalism.
+- Communicating thoughtfully, especially during reviews and governance
+  discussions.
+- Respecting the repository's deterministic pipeline requirements and
+  compliance gates.
+- Following canonical anchor, overlay, and validation rules as defined in
+  AGENTS.md, governance.yaml, sswg.yaml, and mvm.yaml.
+
+Examples of unacceptable behavior include:
+
+- Harassment, discrimination, or personal attacks.
+- Publishing confidential or sensitive information without authorization.
+- Bypassing required validation gates or altering canonical artifacts without
+  approved overlays.
+- Introducing nondeterminism into phases that require determinism.
+
+## Scope
+
+This Code of Conduct applies to all repository spaces (issues, discussions,
+code reviews, documentation, and community communications).
+
+## Reporting
+
+If you experience or witness unacceptable behavior, please report it via a
+GitHub issue labeled `conduct` unless the report is sensitive. For sensitive
+reports, follow the private reporting flow described in SECURITY.md.
+
+## Enforcement
+
+Project maintainers will investigate reports, apply corrective actions, and
+coordinate outcomes consistent with repository governance and compliance
+requirements.

--- a/Developers_Certificate_of_Origin.md
+++ b/Developers_Certificate_of_Origin.md
@@ -1,5 +1,16 @@
-[(Developer's Certificate of Origin 1.1)
-[https://developercertificate.org/]
+---
+anchor:
+  anchor_id: developers_certificate_of_origin
+  anchor_version: "1.0.0"
+  scope: governance
+  owner: sswg
+  status: draft
+---
+
+# Developer's Certificate of Origin 1.1
+
+This repository uses the Developer's Certificate of Origin (DCO) version 1.1
+(see https://developercertificate.org/).
 
 By making a contribution to this project, I certify that:
 
@@ -24,3 +35,15 @@ By making a contribution to this project, I certify that:
     personal information I submit with it, including my sign-off) is
     maintained indefinitely and may be redistributed consistent with
     this project or the open source license(s) involved.
+
+## Sign-off requirement
+
+All commits MUST include a DCO sign-off. Use:
+
+```
+git commit -s
+```
+
+This requirement applies to all contributions alongside the governance and
+compliance rules in AGENTS.md, governance.yaml, and the broader sswg/mvm
+repository policies.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,36 @@
+---
+anchor:
+  anchor_id: security_policy
+  anchor_version: "1.0.0"
+  scope: governance
+  owner: sswg
+  status: draft
+---
+
 # Security Policy
 
-Placeholder content: Security reporting instructions will be documented here. For now, report security issues to the repository owners listed in governance.yaml and follow the disclosure requirements in AGENTS.md.
+## Supported versions
+
+Security fixes are applied to the default branch of this repository. Release
+branches, if any, are supported only when explicitly labeled in release notes.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities through one of the following channels:
+
+1. **Preferred:** Open a GitHub Security Advisory for this repository.
+2. **If the issue is not sensitive:** Open a GitHub issue with a clear title and
+   include the word "security".
+
+When reporting, include:
+
+- A detailed description of the vulnerability and potential impact.
+- Steps to reproduce, including relevant configuration or environment details.
+- Any suggested remediation or mitigation.
+
+## Disclosure expectations
+
+- Do not publicly disclose security issues before maintainers confirm a fix.
+- Follow coordinated disclosure timelines agreed upon in the advisory thread.
+- Security changes must continue to respect sswg/mvm governance, determinism
+  requirements, and validation gates defined in AGENTS.md and governance.yaml.


### PR DESCRIPTION
### Motivation
- Replace placeholder governance docs with concrete guidance that matches current repository practices and governance rules.
- Ensure contributor artifacts carry canonical anchor metadata to support auditability and registry tooling.
- Make contributor obligations explicit (DCO sign-off and reporting flows) and align policies with `AGENTS.md` and `governance.yaml`.

### Description
- Add canonical front-matter anchors to `Developers_Certificate_of_Origin.md`, `CODE_OF_CONDUCT.md`, and `SECURITY.md` and populate each with repository-aligned content.
- Replace placeholder Code of Conduct with a governance-aligned CoC that references deterministic pipeline and overlay/anchor rules.
- Add a DCO sign-off requirement with the `git commit -s` instruction to `Developers_Certificate_of_Origin.md`.
- Expand `SECURITY.md` with preferred reporting channels and disclosure expectations consistent with repository governance.
