### PR TITLE
Mark run_mvm.md as canonical runbook and update docs to reference it

### DIFF
--- a/API/overview.md
+++ b/API/overview.md
@@ -8,6 +8,15 @@ This document provides a **high-level map** of all public interfaces.
 
 ---
 
+# Canonical Runbook
+
+**Primary entrypoint (how to run + expected outputs):**  
+../docs/getting_started/run_mvm.md
+
+Other docs are secondary/overview and should defer to the canonical runbook above.
+
+---
+
 # 🏗 Core Architectural Layers
 
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,15 @@ Author: **Tommy Raven (Thomas Byers)**
 
 ---
 
+## ▶️ Canonical Runbook
+
+**Primary entrypoint (how to run + expected outputs):**  
+docs/getting_started/run_mvm.md
+
+Other docs are secondary/overview and should defer to the canonical runbook above.
+
+---
+
 ## 🧩 System Design Philosophy
 
 **“Teach the workflow how to teach itself.”**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -7,6 +7,11 @@ Licensing: Raven Recordings ©️ see: *LICENSE.md*
 
 # API Reference — SSWG-MVM
 
+**Primary entrypoint (how to run + expected outputs):**  
+getting_started/run_mvm.md
+
+Other docs are secondary/overview and should defer to the canonical runbook above.
+
 ## Overview
 
 The API provides programmatic access to the **SSWG-MVM** workflow generation, evaluation, recursion, and memory systems. It enables developers to initiate workflows, evaluate their quality, recursively refine outputs, and interact with stored workflow histories. The API is designed to support both human-readable and machine-readable outputs and integrates seamlessly with safety, constitution, and risk pipelines while ensuring the SSWG target remains stable through iterations.
@@ -61,4 +66,3 @@ save(expanded_wf)
 * Integrate **Safety Stack** checks (`safety_classifier`, `sandbox_simulator`) for untrusted inputs.
 * Leverage versioning from `ai_recursive.registry` to maintain traceable workflow history.
 * Combine evaluation scores with feedback loops to guide recursive improvements.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,15 @@ The system combines deterministic pipeline execution with semantic evaluation, r
 
 ---
 
+## Canonical Runbook
+
+**Primary entrypoint (how to run + expected outputs):**  
+getting_started/run_mvm.md
+
+Other docs are secondary/overview and should defer to this canonical runbook to avoid drift.
+
+---
+
 ## What This Repository Is
 
 This repository serves as the **canonical skeleton** for SSWG-MVM.

--- a/docs/getting_started/run_mvm.md
+++ b/docs/getting_started/run_mvm.md
@@ -1,5 +1,7 @@
 # Running SSWG-MVM
 
+**Canonical runbook (how to run + expected outputs):** This document is the canonical reference. Other docs are secondary/overview and should defer to the instructions here to avoid drift.
+
 ## Generate a Workflow (default template)
 
 ```bash


### PR DESCRIPTION
### Motivation
- Centralize the canonical “how to run + expected outputs” instructions to reduce ambiguity and documentation drift. 
- Make the primary entrypoint explicit so tooling and users know which doc is authoritative. 
- Ensure high-level API and README entrypoints point to a single runnable reference for consistency.

### Description
- Label `docs/getting_started/run_mvm.md` as the canonical runbook and add a top-line canonical note in that file. 
- Update references in `README.md`, `docs/README.md`, `API/overview.md`, and `docs/API_REFERENCE.md` to point to the canonical runbook (`docs/getting_started/run_mvm.md`).
- Commit message: `Add canonical runbook references` and created the PR titled "Add canonical runbook references".

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69500009e0fc8328935b416ea2e20b8b)