### PR TITLE
Add deterministic runbook and canonical links

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ snapshot without regenerating.
 6. Record lineage snapshot
 7. Auto-bump version if core modules changed
 
+**Canonical run guide:** [docs/RUNBOOK.md](docs/RUNBOOK.md)
+
 ### Reproducible demo
 
 Run the complete recursive pipeline (validation → evaluation → recursion → exports)
@@ -241,6 +243,8 @@ Outputs land in `data/outputs/demo_run` and include:
 ---
 
 ## 🛠 Setup & Usage
+
+**Canonical run guide:** [docs/RUNBOOK.md](docs/RUNBOOK.md)
 
 ### Clone the Repository
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -10,6 +10,8 @@ This Quickstart is intentionally minimal: it gets you from clone â†’ first 
 
 ## ðŸš€ Getting Started
 
+**Canonical run guide:** `docs/RUNBOOK.md`
+
 ### 1. Clone the Canonical Repository
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -76,7 +76,11 @@ This repository exists to:
 
 2. Explore the folder structure and documentation under docs/.
 
-3. Run or inspect the demo pipeline described in:
+3. Follow the canonical run guide:
+
+   docs/RUNBOOK.md
+
+4. Run or inspect the demo pipeline described in:
 
    docs/ARCHITECTURE.md  
    docs/QUICKSTART.md

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,65 @@
+# Deterministic Run Recipe (sswg/mvm)
+
+This runbook is the single canonical guide for deterministic, audit-ready runs of the sswg/mvm pipeline.
+
+## Deterministic Run Recipe
+
+### 1) Validate the PDL phase set
+
+**Command**
+```bash
+python -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas
+```
+
+**Inputs**
+- `pdl/example_full_9_phase.yaml` (full_9_phase declaration)
+- `schemas/` (PDL wrapper + phase schemas)
+
+**Expected result**
+- Validation completes without errors. No artifacts are written; the command prints validation output to stdout/stderr.
+
+---
+
+### 2) Run a deterministic workflow execution
+
+**Command**
+```bash
+python generator/main.py \
+  --workflow-json data/templates/campfire_workflow.json \
+  --no-refine \
+  --out-dir data/outputs
+```
+
+**Inputs**
+- `data/templates/campfire_workflow.json` (seed workflow)
+- `schemas/` (workflow schema validation)
+
+**Expected artifacts (paths, filenames, contents)**
+- `data/outputs/<workflow_id>.json`
+  - Full workflow payload (phases, modules, evaluation summaries, dependency graph metadata).
+- `data/outputs/<workflow_id>.md`
+  - Human-readable phase/task summary with evaluation notes.
+- `data/outputs/workflow_<workflow_id>_<timestamp>.json`
+  - Timestamped visualization JSON export of the workflow payload.
+- `data/outputs/workflow_<workflow_id>_<timestamp>.md`
+  - Timestamped visualization Markdown export (phase overview and metadata).
+- `data/outputs/workflow_graph_<timestamp>.dot`
+  - Graphviz DOT file capturing dependency nodes and edges.
+
+> Determinism note: `--no-refine` disables the recursive refinement step to keep the run deterministic.
+
+---
+
+## Expected Outputs Checklist
+
+### data/outputs/ (repository snapshots)
+- [ ] `data/outputs/meta_template_20251203230038.md`
+- [ ] `data/outputs/training_template_20251207034010.md`
+- [ ] `data/outputs/training_template_20251207034925.md`
+- [ ] `data/outputs/unnamed_workflow.md`
+- [ ] `data/outputs/workflow_001.md`
+
+### Benchmark / profiling artifacts
+- [ ] `data/profiling/workflow_profiling_2025-12-27.json` (profiling summary)
+- [ ] `data/profiling/campfire_workflow/` (profiling run directory)
+- [ ] `data/profiling/technical_procedure_template/` (profiling run directory)


### PR DESCRIPTION
### Motivation
- Provide a single canonical, deterministic run recipe for audit-ready executions and reproducibility.
- Surface the canonical run guide from the top-level docs to improve discoverability and developer onboarding.
- Document exact commands and inputs for PDL validation and deterministic runs to align with schema/gate requirements.
- Record expected outputs and profiling artifacts so CI and reviewers have a concrete checklist for artifact presence.

### Description
- Add `docs/RUNBOOK.md` containing exact commands (`python -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas` and `python generator/main.py --workflow-json data/templates/campfire_workflow.json --no-refine --out-dir data/outputs`), the input files, and the expected artifact paths and high-level contents.
- Link the runbook from `README.md`, `docs/README.md`, and `docs/QUICKSTART.md` as the single canonical run guide.
- Include an "Expected Outputs Checklist" that enumerates files under `data/outputs/` and profiling artifacts under `data/profiling/`.
- This is a documentation-only change with no runtime code modifications.

### Testing
- No automated tests were run for this documentation-only change.
- Documentation build or CI checks were not executed as part of this PR.