### PR TITLE
Point canonical runbook to docs/RUNBOOK.md and add benchmark reproduction instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Author: **Tommy Raven (Thomas Byers)**
 ## ▶️ Canonical Runbook
 
 **Primary entrypoint (how to run + expected outputs):**  
-docs/getting_started/run_mvm.md
+[docs/RUNBOOK.md](docs/RUNBOOK.md)
 
 Other docs are secondary/overview and should defer to the canonical runbook above.
 

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -35,6 +35,28 @@ These calibration benchmarks establish expected metric ranges for quality scorin
 - Evaluate distributions, not just point estimates. Use median and p10 to reduce sensitivity to outliers.
 - Any benchmark falling below the acceptance criteria requires investigation before promotion.
 - Expected ranges are guardrails, not deterministic requirements; they help detect metric drift.
+
+## Reproduce this run
+
+Use the same benchmark command used by local CI:
+
+```bash
+python scripts/local_ci.py bench
+```
+
+Or run the benchmark tracker directly:
+
+```bash
+python -m ai_memory.benchmark_tracker
+```
+
+For calibration guidance and how to interpret expected ranges, see
+[docs/METRICS_SYSTEM.md](METRICS_SYSTEM.md). Benchmark definitions and expected
+ranges live in [`ai_memory/benchmark_tracker.py`](../ai_memory/benchmark_tracker.py).
+
+Environment references (hardware + software baselines, container specs) live
+under [`reproducibility/`](../reproducibility/) to align the run context.
+
 ## ✅ Latest Measured Results (2025-12-27T09:07:21Z)
 
 **Raw results:** [`artifacts/performance/benchmarks_20251227_090721.json`](../artifacts/performance/benchmarks_20251227_090721.json)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -10,7 +10,7 @@ This Quickstart is intentionally minimal: it gets you from clone â†’ first 
 
 ## ðŸš€ Getting Started
 
-**Canonical run guide:** `docs/RUNBOOK.md`
+**Canonical run guide:** [docs/RUNBOOK.md](RUNBOOK.md)
 
 ### 1. Clone the Canonical Repository
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,7 +11,7 @@ The system combines deterministic pipeline execution with semantic evaluation, r
 ## Canonical Runbook
 
 **Primary entrypoint (how to run + expected outputs):**  
-getting_started/run_mvm.md
+[docs/RUNBOOK.md](RUNBOOK.md)
 
 Other docs are secondary/overview and should defer to this canonical runbook to avoid drift.
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -60,6 +60,7 @@ python generator/main.py \
 - [ ] `data/outputs/workflow_001.md`
 
 ### Benchmark / profiling artifacts
+- [ ] `artifacts/performance/benchmarks_20251227_090721.json` (benchmark results)
 - [ ] `data/profiling/workflow_profiling_2025-12-27.json` (profiling summary)
 - [ ] `data/profiling/campfire_workflow/` (profiling run directory)
 - [ ] `data/profiling/technical_procedure_template/` (profiling run directory)


### PR DESCRIPTION
### Motivation
- Unify the canonical run guidance to a single source-of-truth to avoid documentation drift. 
- Make performance benchmark reproduction explicit so reviewers and CI can rerun measured runs. 
- Surface expected benchmark artifacts and environment references to simplify calibration and validation.

### Description
- Updated runbook links in `README.md`, `docs/README.md`, and `docs/QUICKSTART.md` to point to `docs/RUNBOOK.md`.
- Added a "Reproduce this run" section to `docs/PERFORMANCE_BENCHMARKS.md` with the commands `python scripts/local_ci.py bench` and `python -m ai_memory.benchmark_tracker`.
- Linked `docs/METRICS_SYSTEM.md`, `ai_memory/benchmark_tracker.py`, and the `reproducibility/` directory for calibration and environment context guidance.
- Added a benchmark artifact checklist entry (`artifacts/performance/benchmarks_20251227_090721.json`) into `docs/RUNBOOK.md` under expected outputs.

### Testing
- No automated tests were run because this change set is documentation-only.
