### PR TITLE
Fix pylint findings across generator utilities

### DIFF
--- a/generator/agent_policy.py
+++ b/generator/agent_policy.py
@@ -1,11 +1,12 @@
+"""Utilities for enforcing agent policy rules and manifests."""
+
 from __future__ import annotations
 
 import hashlib
-import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, Optional
 
 from generator.hashing import hash_data
 
@@ -18,21 +19,26 @@ PROHIBITED_COMMANDS = (
 
 @dataclass(frozen=True)
 class PolicyState:
+    """Snapshot of policy-related metadata for a repository."""
+
     repo_mode: str
     agents_paths: list[str]
     policy_hash: str
 
 
 def _hash_text(value: str) -> str:
+    """Hash a text payload using SHA-256."""
     payload = value.encode("utf-8")
     return hashlib.sha256(payload).hexdigest()
 
 
 def list_agents_paths(repo_root: Path) -> list[Path]:
+    """Return all AGENTS.md paths under the repository root."""
     return sorted(repo_root.rglob("AGENTS.md"))
 
 
 def build_policy_hash(agents_paths: Iterable[Path]) -> str:
+    """Build a stable policy hash from the discovered AGENTS.md files."""
     entries = []
     for path in agents_paths:
         entries.append(
@@ -45,10 +51,12 @@ def build_policy_hash(agents_paths: Iterable[Path]) -> str:
 
 
 def parse_command(command: str) -> list[str]:
+    """Split a command string into executable and arguments."""
     return [part for part in command.strip().split() if part]
 
 
 def is_prohibited_command(command: str) -> bool:
+    """Return True when a command violates the policy rules."""
     parts = parse_command(command)
     if not parts:
         return False
@@ -60,10 +68,12 @@ def is_prohibited_command(command: str) -> bool:
 
 
 def find_prohibited_commands(commands: Iterable[str]) -> list[str]:
+    """Filter a list of commands down to prohibited entries."""
     return [command for command in commands if is_prohibited_command(command)]
 
 
 def detect_working_tree_changes(repo_root: Path) -> list[str]:
+    """Return porcelain status lines for modified files under the repo."""
     result = subprocess.run(
         ["git", "status", "--porcelain"],
         cwd=repo_root,
@@ -83,6 +93,7 @@ def build_policy_manifest(
     effective_scope: Path,
     prohibited_commands: Iterable[str] = PROHIBITED_COMMANDS,
 ) -> dict:
+    """Build a policy manifest payload with anchor metadata."""
     return {
         "anchor": {
             "anchor_id": "policy_manifest",
@@ -100,6 +111,7 @@ def build_policy_manifest(
 
 
 def policy_state(repo_root: Path, repo_mode: str) -> PolicyState:
+    """Compute the policy state for the current repository tree."""
     agents_paths = list_agents_paths(repo_root)
     return PolicyState(
         repo_mode=repo_mode,
@@ -109,6 +121,7 @@ def policy_state(repo_root: Path, repo_mode: str) -> PolicyState:
 
 
 def read_commands_from_file(commands_file: Optional[Path]) -> list[str]:
+    """Load command entries from a text file if it exists."""
     if commands_file is None or not commands_file.exists():
         return []
     return [

--- a/generator/audit_bundle.py
+++ b/generator/audit_bundle.py
@@ -1,3 +1,5 @@
+"""Audit bundle creation and validation helpers."""
+
 from __future__ import annotations
 
 import hashlib
@@ -5,13 +7,15 @@ import json
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, List
 
 from generator.hashing import hash_data
 
 
 @dataclass(frozen=True)
 class BundleEntry:
+    """Entry for an audited bundle artifact."""
+
     component_id: str
     source_path: Path
     bundle_path: Path
@@ -19,10 +23,12 @@ class BundleEntry:
 
 
 def load_audit_spec(path: Path) -> Dict[str, Any]:
+    """Load the audit bundle specification from disk."""
     return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _hash_file(path: Path) -> str:
+    """Hash file contents using SHA-256."""
     hasher = hashlib.sha256()
     with path.open("rb") as handle:
         for chunk in iter(lambda: handle.read(8192), b""):
@@ -31,6 +37,7 @@ def _hash_file(path: Path) -> str:
 
 
 def _resolve_components(spec: Dict[str, Any], run_id: str) -> List[dict]:
+    """Resolve spec component paths for the provided run ID."""
     components = []
     for component in spec.get("components", []):
         if "path_template" in component:
@@ -54,6 +61,7 @@ def build_bundle(
     bundle_dir: Path,
     manifest_path: Path,
 ) -> Dict[str, Any]:
+    """Create a bundle of audit artifacts and emit a manifest."""
     bundle_dir.mkdir(parents=True, exist_ok=True)
     entries: List[BundleEntry] = []
 
@@ -103,6 +111,7 @@ def build_bundle(
 
 
 def validate_bundle(manifest: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate a bundle manifest against on-disk artifacts."""
     errors = []
     entries = manifest.get("entries", [])
     run_id = manifest.get("run_id")

--- a/generator/autopsy_report.py
+++ b/generator/autopsy_report.py
@@ -1,13 +1,16 @@
+"""Autopsy report utilities for failure diagnostics."""
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, List
 
 from generator.failure_emitter import FailureLabel
 
 
 def _extract_invariant_ids(evidence: Dict[str, Any]) -> List[str]:
+    """Extract invariant identifiers from failure evidence."""
     invariant_ids: List[str] = []
     if not evidence:
         return invariant_ids
@@ -26,6 +29,7 @@ def build_autopsy_report(
     failure: FailureLabel,
     invariants_registry: Dict[str, Any],
 ) -> Dict[str, Any]:
+    """Build an autopsy report payload from a failure label."""
     registry_invariants = {
         invariant.get("id"): invariant
         for invariant in invariants_registry.get("invariants", [])
@@ -57,5 +61,6 @@ def build_autopsy_report(
 
 
 def write_autopsy_report(path: Path, report: Dict[str, Any]) -> None:
+    """Write an autopsy report to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(report, indent=2), encoding="utf-8")

--- a/generator/budgeting.py
+++ b/generator/budgeting.py
@@ -1,23 +1,28 @@
+"""Budget evaluation utilities for runtime and artifacts."""
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List
 
 from generator.hashing import hash_data
 
 
 def load_budget_spec(path: Path) -> Dict[str, Any]:
+    """Load a budget specification from JSON."""
     return json.loads(path.read_text(encoding="utf-8"))
 
 
 def _size_bytes(path: Path) -> int | None:
+    """Return size of the file in bytes, or None if missing."""
     if not path.exists():
         return None
     return path.stat().st_size
 
 
 def collect_artifact_sizes(artifact_budgets: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collect artifact sizes for budget evaluation."""
     results: List[Dict[str, Any]] = []
     for budget in artifact_budgets:
         paths = [Path(path) for path in budget.get("paths", [])]
@@ -47,6 +52,8 @@ def evaluate_budgets(
     phase_durations: Dict[str, float],
     artifact_sizes: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
+    # pylint: disable=too-many-locals
+    """Evaluate phase duration and artifact size budgets."""
     phase_results = []
     for phase, limits in budget_spec.get("phase_budgets", {}).items():
         max_duration = float(limits.get("max_duration_sec", 0))

--- a/generator/evaluation_spec.py
+++ b/generator/evaluation_spec.py
@@ -1,3 +1,5 @@
+"""Evaluation specification schema helpers."""
+
 from __future__ import annotations
 
 import json
@@ -8,10 +10,12 @@ from jsonschema import Draft202012Validator, RefResolver
 
 
 def _load_schema(schema_path: Path) -> Dict[str, Any]:
+    """Load a JSON schema from disk."""
     return json.loads(schema_path.read_text(encoding="utf-8"))
 
 
 def get_evaluation_spec_validator(schema_dir: Path) -> Draft202012Validator:
+    """Build a JSON schema validator for evaluation specs."""
     schema = _load_schema(schema_dir / "evaluation-spec.json")
     base_uri = schema_dir.as_uri().rstrip("/") + "/"
     resolver = RefResolver(base_uri=base_uri, referrer=schema)
@@ -24,6 +28,7 @@ def validate_evaluation_spec(
     schema_dir: Path,
     spec_path: Path | None = None,
 ) -> List[Dict[str, Any]]:
+    """Validate a spec payload and return a list of errors."""
     validator = get_evaluation_spec_validator(schema_dir)
     errors = sorted(validator.iter_errors(spec), key=lambda e: e.path)
     return [

--- a/generator/failure_emitter.py
+++ b/generator/failure_emitter.py
@@ -1,3 +1,5 @@
+"""Failure label creation and persistence helpers."""
+
 from __future__ import annotations
 
 import json
@@ -19,13 +21,16 @@ ALLOWED_FAILURE_TYPES = {
 
 
 @dataclass(frozen=True)
-class FailureLabel:
+class FailureLabel:  # pylint: disable=invalid-name
+    """Structured failure label payload."""
+
     Type: str
     message: str
     phase_id: str
     evidence: Optional[Dict[str, Any]] = None
 
     def as_dict(self) -> Dict[str, Any]:
+        """Return the label as a serializable dictionary."""
         payload: Dict[str, Any] = {
             "Type": self.Type,
             "message": self.message,
@@ -37,6 +42,7 @@ class FailureLabel:
 
 
 def validate_failure_label(label: FailureLabel) -> None:
+    """Validate the failure label contents against allowed types."""
     if label.Type not in ALLOWED_FAILURE_TYPES:
         raise ValueError(f"Unknown failure Type: {label.Type}")
     if not label.message:
@@ -45,8 +51,11 @@ def validate_failure_label(label: FailureLabel) -> None:
         raise ValueError("Failure label phase_id must be non-empty")
 
 
-class FailureEmitter:
+class FailureEmitter:  # pylint: disable=too-few-public-methods
+    """Emit failure label payloads to disk."""
+
     def __init__(self, output_dir: Path) -> None:
+        """Initialize the emitter output directory."""
         self.output_dir = output_dir
         self.output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -57,6 +66,7 @@ class FailureEmitter:
         run_id: str,
         context: Optional[Dict[str, Any]] = None,
     ) -> Path:
+        """Write a failure label payload to disk and return its path."""
         validate_failure_label(label)
         sanitized_label = FailureLabel(
             Type=label.Type,

--- a/generator/hashing.py
+++ b/generator/hashing.py
@@ -1,3 +1,5 @@
+"""Hashing helpers for canonical payloads."""
+
 from __future__ import annotations
 
 import hashlib
@@ -6,9 +8,11 @@ from typing import Any
 
 
 def canonicalize_json(data: Any) -> str:
+    """Serialize JSON deterministically for hashing."""
     return json.dumps(data, sort_keys=True, separators=(",", ":"))
 
 
 def hash_data(data: Any) -> str:
+    """Return a SHA-256 hash for a canonicalized payload."""
     payload = canonicalize_json(data).encode("utf-8")
     return hashlib.sha256(payload).hexdigest()

--- a/generator/invariant_registry.py
+++ b/generator/invariant_registry.py
@@ -1,3 +1,5 @@
+"""Invariant registry loading and coverage utilities."""
+
 from __future__ import annotations
 
 import json
@@ -22,6 +24,7 @@ CANONICAL_PHASES = {
 
 
 def load_invariants_yaml(path: Path) -> List[Dict[str, Any]]:
+    """Load invariants from YAML."""
     payload = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError("invariants.yaml must contain a mapping")
@@ -32,6 +35,7 @@ def load_invariants_yaml(path: Path) -> List[Dict[str, Any]]:
 
 
 def load_registry(path: Path) -> Dict[str, Any]:
+    """Load invariant registry JSON from disk."""
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         raise ValueError("invariants registry must be a mapping")
@@ -39,6 +43,8 @@ def load_registry(path: Path) -> Dict[str, Any]:
 
 
 def validate_registry(payload: Dict[str, Any]) -> List[str]:
+    """Validate invariant registry structure."""
+    # pylint: disable=too-many-branches
     errors: List[str] = []
     anchor = payload.get("anchor")
     if not isinstance(anchor, dict):
@@ -92,6 +98,7 @@ def validate_registry(payload: Dict[str, Any]) -> List[str]:
 
 
 def resolve_enforcement_paths(targets: Iterable[str], repo_root: Path) -> List[Dict[str, Any]]:
+    """Resolve enforcement targets to filesystem paths."""
     resolved: List[Dict[str, Any]] = []
     for target in targets:
         if not isinstance(target, str) or not target:
@@ -108,6 +115,7 @@ def resolve_enforcement_paths(targets: Iterable[str], repo_root: Path) -> List[D
 
 
 def resolve_documentation_paths(targets: Iterable[str], repo_root: Path) -> List[Dict[str, Any]]:
+    """Resolve documentation targets to filesystem paths."""
     resolved: List[Dict[str, Any]] = []
     for target in targets:
         if not isinstance(target, str) or not target:
@@ -126,6 +134,8 @@ def build_coverage_report(
     registry_payload: Dict[str, Any],
     repo_root: Path,
 ) -> Dict[str, Any]:
+    """Build an invariant coverage report from registry metadata."""
+    # pylint: disable=too-many-locals
     declared_ids = [item.get("id") for item in declared_invariants if item.get("id")]
     registry_invariants = registry_payload.get("invariants", [])
     registry_ids = [item.get("id") for item in registry_invariants if item.get("id")]

--- a/generator/overlay_governance.py
+++ b/generator/overlay_governance.py
@@ -1,3 +1,5 @@
+"""Overlay governance validation helpers."""
+
 from __future__ import annotations
 
 import json
@@ -8,10 +10,12 @@ from jsonschema import Draft202012Validator, RefResolver
 
 
 def _load_schema(schema_path: Path) -> Dict[str, Any]:
+    """Load a JSON schema from disk."""
     return json.loads(schema_path.read_text(encoding="utf-8"))
 
 
 def get_overlay_validator(schema_dir: Path) -> Draft202012Validator:
+    """Return a validator for overlay descriptors."""
     schema = _load_schema(schema_dir / "overlay-descriptor.json")
     base_uri = schema_dir.as_uri().rstrip("/") + "/"
     resolver = RefResolver(base_uri=base_uri, referrer=schema)
@@ -24,6 +28,7 @@ def validate_overlay_descriptor(
     schema_dir: Path,
     overlay_path: Path | None = None,
 ) -> List[Dict[str, Any]]:
+    """Validate an overlay descriptor and return lint results."""
     validator = get_overlay_validator(schema_dir)
     errors = sorted(validator.iter_errors(overlay), key=lambda e: e.path)
     results: List[Dict[str, Any]] = [
@@ -125,6 +130,7 @@ def validate_overlay_descriptor(
 
 
 def detect_overlay_ambiguity(overlays: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Detect ambiguous override ordering in overlays."""
     errors: List[Dict[str, Any]] = []
     scope_path_map: Dict[tuple[str, str], List[Dict[str, Any]]] = {}
 
@@ -167,6 +173,7 @@ def build_overlay_promotion_report(
     lint_errors: Dict[str, List[Dict[str, Any]]],
     ambiguity_errors: List[Dict[str, Any]],
 ) -> Dict[str, Any]:
+    """Build a promotion report for overlay descriptors."""
     ambiguity_map: Dict[str, List[Dict[str, Any]]] = {}
     for error in ambiguity_errors:
         for overlay_id in error.get("overlay_ids", []):

--- a/generator/pdl_validator.py
+++ b/generator/pdl_validator.py
@@ -23,13 +23,15 @@ SCHEMAS_DIR = Path(__file__).resolve().parent.parent / "schemas"
 
 
 @dataclass
-class PDLFailureLabel:
+class PDLFailureLabel:  # pylint: disable=invalid-name
+    """Failure label used by PDL validation."""
     Type: str
     message: str
     phase_id: Optional[str] = None
     evidence: Optional[Dict[str, Any]] = None
 
     def as_dict(self) -> Dict[str, Any]:
+        """Return the label as a serializable dictionary."""
         payload: Dict[str, Any] = {
             "Type": self.Type,
             "message": self.message,
@@ -42,12 +44,15 @@ class PDLFailureLabel:
 
 
 class PDLValidationError(RuntimeError):
+    """Raised when PDL validation fails."""
+
     def __init__(self, label: PDLFailureLabel) -> None:
         super().__init__(label.message)
         self.label = label
 
 
 def _load_schema(schema_dir: Path, schema_name: str) -> Dict[str, Any]:
+    """Load a JSON schema from disk."""
     schema_path = schema_dir / schema_name
     if not schema_path.exists():
         raise FileNotFoundError(f"Schema file not found: {schema_path}")
@@ -55,6 +60,7 @@ def _load_schema(schema_dir: Path, schema_name: str) -> Dict[str, Any]:
 
 
 def _get_validator(schema_dir: Path, schema_name: str) -> Draft202012Validator:
+    """Build a JSON schema validator with a local ref store."""
     schema_dir = schema_dir.resolve()
     schema = _load_schema(schema_dir, schema_name)
     store: Dict[str, Any] = {}
@@ -71,6 +77,7 @@ def _get_validator(schema_dir: Path, schema_name: str) -> Draft202012Validator:
 
 
 def _load_pdl_yaml(path: Path) -> Dict[str, Any]:
+    """Load a PDL YAML file and return it as a mapping."""
     data = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(data, dict):
         raise ValueError("PDL YAML must parse to a mapping object")
@@ -83,6 +90,7 @@ def validate_pdl_object(
     schema_dir: Path = SCHEMAS_DIR,
     schema_name: str = "pdl.json",
 ) -> None:
+    """Validate a PDL object against the schema."""
     try:
         validator = _get_validator(schema_dir, schema_name)
     except FileNotFoundError as exc:
@@ -119,6 +127,7 @@ def validate_pdl_file(
     schema_dir: Path = SCHEMAS_DIR,
     schema_name: str = "pdl.json",
 ) -> None:
+    """Validate a PDL YAML file against the schema."""
     try:
         pdl_obj = _load_pdl_yaml(path)
     except (OSError, ValueError, yaml.YAMLError) as exc:
@@ -140,6 +149,7 @@ def validate_pdl_file_with_report(
     report_dir: Path,
     run_id: str,
 ) -> None:
+    """Validate a PDL file and emit a validation report."""
     schema_path = schema_dir / "pdl.json"
     try:
         validate_pdl_file(pdl_path, schema_dir=schema_dir)
@@ -179,6 +189,7 @@ def _write_validation_report(
     report_dir: Path,
     run_id: str,
 ) -> Path:
+    """Write a validation report payload to disk."""
     report_dir.mkdir(parents=True, exist_ok=True)
     payload = {
         "anchor": {
@@ -201,6 +212,7 @@ def _write_validation_report(
 
 
 def _parse_args() -> argparse.Namespace:
+    """Parse command line arguments for PDL validation."""
     parser = argparse.ArgumentParser(
         description="Validate a PDL YAML file against the PDL schema.",
     )

--- a/generator/phase_evidence.py
+++ b/generator/phase_evidence.py
@@ -1,14 +1,17 @@
+"""Phase evidence bundle utilities."""
+
 from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Optional
 
 from generator.failure_emitter import FailureLabel
 from generator.hashing import hash_data
 
 
 def _hash_payload(payload: Any) -> str:
+    """Hash a payload for phase evidence."""
     return hash_data(payload)
 
 
@@ -21,6 +24,8 @@ def build_phase_evidence_bundle(
     invariants_registry: Dict[str, Any],
     failures_by_phase: Optional[Dict[str, FailureLabel]] = None,
 ) -> Dict[str, Any]:
+    """Build a phase evidence bundle for a run."""
+    # pylint: disable=too-many-locals
     failures_by_phase = failures_by_phase or {}
     registry_invariants = invariants_registry.get("invariants", [])
 
@@ -62,5 +67,6 @@ def build_phase_evidence_bundle(
 
 
 def write_phase_evidence_bundle(path: Path, bundle: Dict[str, Any]) -> None:
+    """Write a phase evidence bundle to disk."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(bundle, indent=2), encoding="utf-8")

--- a/generator/sanitizer.py
+++ b/generator/sanitizer.py
@@ -1,3 +1,5 @@
+"""Sanitization helpers for sensitive payloads."""
+
 from __future__ import annotations
 
 import math
@@ -31,6 +33,7 @@ HIGH_ENTROPY_THRESHOLD = 4.0
 
 
 def shannon_entropy(value: str) -> float:
+    """Compute Shannon entropy for a string."""
     if not value:
         return 0.0
     counts = {}
@@ -41,12 +44,14 @@ def shannon_entropy(value: str) -> float:
 
 
 def _truncate(value: str) -> str:
+    """Truncate long strings for safe logging."""
     if len(value) <= MAX_STRING_LENGTH:
         return value
     return value[:MAX_STRING_LENGTH] + "...[TRUNCATED]"
 
 
 def redact_text(value: str) -> str:
+    """Redact secrets and high-entropy tokens from a string."""
     redacted = value
     for pattern in SECRET_PATTERNS:
         redacted = pattern.sub("[REDACTED]", redacted)
@@ -57,6 +62,7 @@ def redact_text(value: str) -> str:
 
 
 def find_secret_indicators(value: str) -> list[str]:
+    """Return matching secret indicators for a string."""
     indicators: list[str] = []
     for pattern in SECRET_PATTERNS:
         if pattern.search(value):
@@ -69,6 +75,7 @@ def find_secret_indicators(value: str) -> list[str]:
 
 
 def _sanitize_mapping(data: Mapping[str, Any]) -> dict[str, Any]:
+    """Sanitize a mapping by redacting sensitive keys."""
     sanitized: dict[str, Any] = {}
     for key, value in data.items():
         key_lower = key.lower()
@@ -80,10 +87,12 @@ def _sanitize_mapping(data: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _sanitize_iterable(values: Iterable[Any]) -> list[Any]:
+    """Sanitize a list of values."""
     return [sanitize_payload(value) for value in values]
 
 
 def sanitize_payload(value: Any) -> Any:
+    """Sanitize a payload recursively."""
     if isinstance(value, Mapping):
         return _sanitize_mapping(value)
     if isinstance(value, (list, tuple)):

--- a/generator/secret_scanner.py
+++ b/generator/secret_scanner.py
@@ -1,3 +1,5 @@
+"""Secret scanning utilities with allowlist support."""
+
 from __future__ import annotations
 
 import fnmatch
@@ -5,7 +7,7 @@ import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Iterable, List, Optional
+from typing import Iterable, Optional
 
 from generator.sanitizer import find_secret_indicators
 
@@ -14,7 +16,9 @@ CANONICAL_DIRS = ("generator", "cli", "pdl", "reproducibility")
 
 
 @dataclass(frozen=True)
-class AllowlistEntry:
+class AllowlistEntry:  # pylint: disable=too-many-instance-attributes
+    """Allowlist entry for secret scanning."""
+
     entry_id: str
     path_glob: str
     pattern: str
@@ -26,6 +30,7 @@ class AllowlistEntry:
 
 
 def _parse_allowlist(path: Path) -> list[AllowlistEntry]:
+    """Parse allowlist entries from JSON."""
     payload = json.loads(path.read_text(encoding="utf-8"))
     entries = []
     for raw in payload.get("entries", []):
@@ -45,6 +50,7 @@ def _parse_allowlist(path: Path) -> list[AllowlistEntry]:
 
 
 def _is_expired(timestamp: str) -> bool:
+    """Return True when the allowlist entry has expired."""
     try:
         expires = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
     except ValueError:
@@ -53,12 +59,14 @@ def _is_expired(timestamp: str) -> bool:
 
 
 def load_allowlist(path: Optional[Path]) -> list[AllowlistEntry]:
+    """Load allowlist entries from disk if present."""
     if path is None or not path.exists():
         return []
     return _parse_allowlist(path)
 
 
 def _matches_entry(entry: AllowlistEntry, path: Path, indicators: Iterable[str]) -> bool:
+    """Return True when a path/indicator pair matches an allowlist entry."""
     if not fnmatch.fnmatch(str(path), entry.path_glob):
         return False
     if entry.pattern and entry.pattern not in indicators:
@@ -67,11 +75,13 @@ def _matches_entry(entry: AllowlistEntry, path: Path, indicators: Iterable[str])
 
 
 def _is_canonical_path(path: Path) -> bool:
+    """Return True when the path is in a canonical directory."""
     parts = path.parts
     return len(parts) > 0 and parts[0] in CANONICAL_DIRS
 
 
 def _scan_text(content: str) -> list[str]:
+    """Scan a content string for secret indicators."""
     indicators = set()
     for line in content.splitlines():
         indicators.update(find_secret_indicators(line))
@@ -79,6 +89,7 @@ def _scan_text(content: str) -> list[str]:
 
 
 def scan_file(path: Path) -> list[str]:
+    """Scan a single file and return secret indicators."""
     if path.name.endswith(".env"):
         return ["env_file"]
     try:
@@ -93,20 +104,35 @@ def scan_paths(
     *,
     allowlist: list[AllowlistEntry],
 ) -> dict:
+    """Scan paths for secrets and apply allowlist rules."""
     violations = []
     allowlist_errors = []
     for entry in allowlist:
         if not entry.entry_id or not entry.path_glob:
-            allowlist_errors.append({"entry_id": entry.entry_id, "reason": "missing required fields"})
+            allowlist_errors.append(
+                {"entry_id": entry.entry_id, "reason": "missing required fields"}
+            )
             continue
         if not entry.approved_by or not entry.approval_ref:
-            allowlist_errors.append({"entry_id": entry.entry_id, "reason": "missing approval metadata"})
+            allowlist_errors.append(
+                {
+                    "entry_id": entry.entry_id,
+                    "reason": "missing approval metadata",
+                }
+            )
             continue
         if _is_expired(entry.expires_at):
-            allowlist_errors.append({"entry_id": entry.entry_id, "reason": "allowlist entry expired"})
+            allowlist_errors.append(
+                {"entry_id": entry.entry_id, "reason": "allowlist entry expired"}
+            )
             continue
         if entry.allow_on_canonical:
-            allowlist_errors.append({"entry_id": entry.entry_id, "reason": "allowlist cannot apply to canonical"})
+            allowlist_errors.append(
+                {
+                    "entry_id": entry.entry_id,
+                    "reason": "allowlist cannot apply to canonical",
+                }
+            )
             continue
 
     for path in paths:
@@ -128,6 +154,7 @@ def _scan_single_path(
     allowlist: list[AllowlistEntry],
     allowlist_errors: list[dict],
 ) -> list[dict]:
+    """Scan a path and apply allowlist rules for violations."""
     indicators = scan_file(path)
     if not indicators:
         return []

--- a/modules/llm_adapter.py
+++ b/modules/llm_adapter.py
@@ -51,6 +51,7 @@ class RefinementContract:
     )
 
     def validate(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        """Validate payload against required fields and type rules."""
         for field_name in self.required_fields:
             if field_name not in payload:
                 raise ValueError(f"Missing required field: {field_name}")


### PR DESCRIPTION
### Motivation
- Address multiple pylint warnings across the generator and related modules to improve code quality and maintainability.
- Provide descriptive module/class/function docstrings to satisfy style checks and clarify intent.
- Normalize helper names and small refactors to resolve invalid-name and import-order concerns.
- Apply minimal, localized fixes (docstrings, naming, small refactors, and selective pylint disables) without changing runtime behavior.

### Description
- Added module-, class-, and function-level docstrings across many `generator/*` modules and `modules/llm_adapter.py` to resolve missing-docstring warnings and clarify responsibilities.
- Refactored `generator/exporters.py` to introduce `WorkflowSections`, use `collections.abc.Mapping` for mapping checks, and replaced short file-handle variable names with `file_handle` to address naming and readability issues.
- Fixed various style issues (line-wrapping, import placement, parameter formatting), added targeted `pylint: disable` annotations where complexity or legacy constraints made smaller refactors impractical, and renamed local variables for clarity in `generator/main.py` and other modules.
- Preserved public behavior while improving static quality: changes are limited to docstrings, naming, small control-flow reworks, and helper extraction across multiple modules (see modified files list in the commit for details).

### Testing
- ⚠️ No automated tests were executed as part of this change.
- ⚠️ Linting was the primary target for this update and the edits were implemented to address the reported pylint issues, but a full lint pass was not re-run in CI as part of this PR.