### PR TITLE
Use python3 in documentation examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,9 @@ The root [README.md](./README.md) and [docs/README.md](./docs/README.md) describ
 ## Getting started
 1. Read the root [README.md](./README.md) to understand goals and boundaries.
 2. Skim [docs/README.md](./docs/README.md) for documentation structure and navigation.
-3. Run local setup using `python -m venv .venv && source .venv/bin/activate && pip install -r REQUIREMENTS.txt`.
+3. Run local setup using `python3 -m venv .venv && source .venv/bin/activate && pip install -r REQUIREMENTS.txt`.
 4. Validate the canonical PDL before running workflows:
-   `python -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas`.
+   `python3 -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas`.
 5. Execute relevant smoke tests or linting before opening a PR.
 
 ## Change workflow

--- a/docs/CONTRIBUTOR_GUIDE.md
+++ b/docs/CONTRIBUTOR_GUIDE.md
@@ -52,7 +52,7 @@ uvicorn src.web.app:app --reload
 
 Run CLI examples:
 
-python generator/main.py --purpose "Design an AI ethics curriculum"
+python3 generator/main.py --purpose "Design an AI ethics curriculum"
 
 Generated workflows appear in `data/workflows/` and logs in `logs/workflow.log`.
 

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -41,13 +41,13 @@ These calibration benchmarks establish expected metric ranges for quality scorin
 Use the same benchmark command used by local CI:
 
 ```bash
-python scripts/local_ci.py bench
+python3 scripts/local_ci.py bench
 ```
 
 Or run the benchmark tracker directly:
 
 ```bash
-python -m ai_memory.benchmark_tracker
+python3 -m ai_memory.benchmark_tracker
 ```
 
 For calibration guidance and how to interpret expected ranges, see

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -36,7 +36,7 @@ For fully reproducible environments, see:
 ### 3. Run the Main Generator
 
 ```bash
-python generator/main.py
+python3 generator/main.py
 ```
 
 This executes the default MVM pipeline:

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -8,7 +8,7 @@
 
 **Command**
 ```bash
-python -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas
+python3 -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas
 ```
 
 **Inputs**
@@ -24,7 +24,7 @@ python -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas
 
 **Command**
 ```bash
-python generator/main.py \
+python3 generator/main.py \
   --workflow-json data/templates/campfire_workflow.json \
   --no-refine \
   --out-dir data/outputs

--- a/docs/compliance/compliance_checklist.md
+++ b/docs/compliance/compliance_checklist.md
@@ -2,11 +2,11 @@
 
 | Gate | Command | Artifact | Pass criteria |
 | --- | --- | --- | --- |
-| PDL schema validation | `python -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas --report-dir artifacts/validation --run-id <run_id>` | `artifacts/validation/pdl_validation_<hash>.json` | `result: pass` |
-| Phase schema validation | `python scripts/validate_pdl_artifacts.py --pdl-dir pdl --schema-dir schemas --report-dir artifacts/validation --run-id <run_id>` | `artifacts/validation/pdl_validation_<hash>.json` | All PDL validations pass |
-| Phase IO manifest + collapse detection | `python scripts/generate_phase_io_manifest.py pdl/example_full_9_phase.yaml --observed tests/fixtures/observed_io.json --output artifacts/phase_io/phase_io_manifest.json --run-id <run_id>` | `artifacts/phase_io/phase_io_manifest.json` | No phase collapse failure |
-| Determinism replay | `python scripts/run_determinism_replay.py --phase-outputs tests/fixtures/phase_outputs.json --output artifacts/determinism/determinism_report.json --run-id <run_id>` | `artifacts/determinism/determinism_report.json` | `match: true` |
+| PDL schema validation | `python3 -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas --report-dir artifacts/validation --run-id <run_id>` | `artifacts/validation/pdl_validation_<hash>.json` | `result: pass` |
+| Phase schema validation | `python3 scripts/validate_pdl_artifacts.py --pdl-dir pdl --schema-dir schemas --report-dir artifacts/validation --run-id <run_id>` | `artifacts/validation/pdl_validation_<hash>.json` | All PDL validations pass |
+| Phase IO manifest + collapse detection | `python3 scripts/generate_phase_io_manifest.py pdl/example_full_9_phase.yaml --observed tests/fixtures/observed_io.json --output artifacts/phase_io/phase_io_manifest.json --run-id <run_id>` | `artifacts/phase_io/phase_io_manifest.json` | No phase collapse failure |
+| Determinism replay | `python3 scripts/run_determinism_replay.py --phase-outputs tests/fixtures/phase_outputs.json --output artifacts/determinism/determinism_report.json --run-id <run_id>` | `artifacts/determinism/determinism_report.json` | `match: true` |
 | Failure labeling tests | `pytest tests/test_failure_emitter.py` | `artifacts/failures/failure_<hash>.json` (on fail) | All tests pass |
-| Anchor enforcement | `python scripts/validate_anchors.py artifacts/validation/pdl_validation_<hash>.json --registry config/anchor_registry.json --run-id <run_id>` | `config/anchor_registry.json` | Anchor registered or canonical lock enforced |
-| Overlay validation | `python scripts/validate_overlay.py tests/fixtures/overlay_descriptor.json` | `artifacts/failures/failure_<hash>.json` (on fail) | Overlay descriptor passes |
-| Promotion readiness gate | `python scripts/run_promotion_readiness.py --run-id <run_id>` | `artifacts/evidence_pack/<run_id>/` | All gates pass, evidence pack present |
+| Anchor enforcement | `python3 scripts/validate_anchors.py artifacts/validation/pdl_validation_<hash>.json --registry config/anchor_registry.json --run-id <run_id>` | `config/anchor_registry.json` | Anchor registered or canonical lock enforced |
+| Overlay validation | `python3 scripts/validate_overlay.py tests/fixtures/overlay_descriptor.json` | `artifacts/failures/failure_<hash>.json` (on fail) | Overlay descriptor passes |
+| Promotion readiness gate | `python3 scripts/run_promotion_readiness.py --run-id <run_id>` | `artifacts/evidence_pack/<run_id>/` | All gates pass, evidence pack present |


### PR DESCRIPTION
### Motivation
- Ensure documentation examples invoke the explicit `python3` interpreter to avoid ambiguity across environments.
- Improve consistency across contributor, quickstart, runbook, performance, and compliance documentation.
- Align examples with repository Python 3.x requirements and modern interpreter usage.

### Description
- Replace occurrences of `python` with `python3` in code blocks and inline command examples across docs.
- Updated files: `CONTRIBUTING.md`, `docs/CONTRIBUTOR_GUIDE.md`, `docs/QUICKSTART.md`, `docs/RUNBOOK.md`, `docs/PERFORMANCE_BENCHMARKS.md`, and `docs/compliance/compliance_checklist.md`.
- Changes are documentation-only and do not modify application code or runtime behavior.

### Testing
- ⚠️ No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ed4cb3788328b703386eb4b5fdff)