### PR TITLE
Fix duplicated validation logging/raise block in ai_core/orchestrator.py

### DIFF
--- a/ai_core/orchestrator.py
+++ b/ai_core/orchestrator.py
@@ -331,18 +331,6 @@ class Orchestrator:
                 {"workflow_id": wf_id},
             )
 
-                # MVM decision: raise, but this could be downgraded later.
-                raise ValueError(f"Invalid workflow schema for {wf_id}")
-
-            log_event(
-                "orchestrator.validation_passed",
-                {"workflow_id": wf_id},
-            )
-            self.telemetry.record(
-                "validation_passed",
-                {"workflow_id": wf_id},
-            )
-
         # Save to memory and render dashboard
         self.memory.save(workflow.to_dict())
         self.dashboard.render()


### PR DESCRIPTION
### Motivation
- Fix a hard syntax/control-flow error in `ai_core/orchestrator.py` where a duplicated, mis-indented validation/telemetry logging and `raise` block prevented importing `generator/main.py` and caused `pytest` collection to fail.
- Restore the canonical validation flow so the orchestrator emits validation-failed metadata and raises exactly once, and validation-passed telemetry is recorded only once.
- Allow test collection and downstream pipeline checks to proceed by removing the duplicated code that produced import-time failures.

### Description
- Remove the duplicated/mis-indented validation logging and `raise ValueError` block in `ai_core/orchestrator.py` and consolidate the `validation_passed` telemetry call.
- Preserve the existing failure handling: incident creation, metadata application, logging, and the `raise` on invalid schema remain on the single, correct code path.
- Commit the change to the repository (`ai_core/orchestrator.py`) to restore clean control flow for imports.

### Testing
- No automated tests were run as part of this change; `pytest` was not executed. 
- Before the fix, `pytest` failed during collection due to the import error originating from `ai_core/orchestrator.py`, and this change targets that root cause.
