### PR TITLE
Add PDL runtime executor, canonical phase constants, CI PDL validation, and ignore build artifacts

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -59,6 +59,15 @@ jobs:
               pip install -r build/REQUIREMENTS.txt
           pip install fastapi uvicorn flake8 pytest httpx pytest rich black json
 
+      - name: 🧩 Compile Python sources
+        run: |
+          python -m compileall .
+
+      - name: 🧪 Validate PDL defaults
+        run: |
+          python -m generator.pdl_validator pdl/default-pdf.yaml --resolve-handlers
+          python -m generator.pdl_validator pdl/example_full_9_phase.yaml --resolve-handlers
+          python scripts/validate_pdl_defaults.py
 
       - name: 🧪 Execute tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ env/
 # Test / tooling artifacts
 # -------------------------
 .pytest_cache/
+.mypy_cache/
+.coverage
+coverage.xml
+htmlcov/
+.tox/
 
 # -------------------------
 # OS / editor cruft
@@ -61,3 +66,4 @@ data/outputs/*
 !data/outputs/workflow_001.md
 data/
 build/
+dist/

--- a/README.md
+++ b/README.md
@@ -88,10 +88,18 @@ Other docs are secondary/overview and should defer to the canonical runbook abov
 
 ---
 
-## ⚡ Quick Start (Bounded Cognition)
+## ⚡ Quick Start (Canonical PDL Run)
+
+Run the runtime-driven PDL flow with the canonical 9-phase definition:
 
 ```bash
-python -m generator.recursion_manager --bounded
+python3 generator/main.py --pdl pdl/default-pdf.yaml --demo
+```
+
+Expected outputs (including the PDL run report) land in:
+
+```
+data/outputs/demo_run/
 ```
 
 See [CHANGELOG.md](CHANGELOG.md) for the v1.2.0 release notes.
@@ -254,20 +262,16 @@ sswg-mvm enforces the canonical phase order:
 
 **Canonical run guide:** [docs/RUNBOOK.md](docs/RUNBOOK.md)
 
-### Reproducible demo
+### Reproducible demo (PDL runtime)
 
-Run the complete recursive pipeline (validation → evaluation → recursion → exports)
-from the repo root with a single command:
+Run the PDL-driven runtime pipeline from the repo root:
 
 ```bash
-python3 generator/main.py --demo --preview
+python3 generator/main.py --pdl pdl/default-pdf.yaml --demo
 ```
 
 Outputs land in `data/outputs/demo_run` and include:
-- Refined workflow JSON + Markdown
-- Mermaid + Graphviz diagrams
-- Before/after metric plot (`metrics_before_after.svg`)
-- Evaluation deltas and history snapshots
+- PDL run report (`pdl_runs/*.json`)
 
 ---
 
@@ -303,18 +307,18 @@ Outputs land in `data/outputs/demo_run` and include:
 
 ### Run the Generator (exact entry path)
 
-    python3 generator/main.py --template creative --preview
+    python3 generator/main.py --pdl pdl/default-pdf.yaml --demo
 
 Artifacts will be created under:
 
-    data/outputs/
+    data/outputs/demo_run/
 
 
 ## 🧪 Testing
 
 Run the full test suite:
 
-    pytest -v
+    pytest -q tests
 
 Test coverage includes:
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -33,18 +33,16 @@ For fully reproducible environments, see:
 
 ---
 
-### 3. Run the Main Generator
+### 3. Run the Canonical PDL Entry Point
 
 ```bash
-python3 generator/main.py
+python3 generator/main.py --pdl pdl/default-pdf.yaml --demo
 ```
 
-This executes the default MVM pipeline:
-- schema validation
-- dependency resolution
-- workflow generation
-- evaluation and scoring
-- export of artifacts
+This executes the runtime-driven PDL pipeline:
+- PDL schema validation + handler resolution
+- canonical 9-phase execution
+- PDL run report emission
 
 ---
 
@@ -82,7 +80,7 @@ The system produces:
 All generated outputs, diagrams, metrics, and history snapshots are written to:
 
 ```
-data/outputs/
+data/outputs/demo_run/
 ```
 
 Artifacts are additive-only and versioned for traceability.
@@ -141,6 +139,16 @@ The MVM pipeline follows the canonical 9-phase flow:
 9. log
 
 Exact execution order and responsibilities are defined in `docs/ARCHITECTURE.md`.
+
+---
+
+## 🧪 Tests
+
+Run the test suite:
+
+```bash
+pytest -q tests
+```
 
 ---
 

--- a/generator/invariant_registry.py
+++ b/generator/invariant_registry.py
@@ -9,18 +9,7 @@ from typing import Any, Dict, Iterable, List
 import yaml
 
 from generator.failure_emitter import ALLOWED_FAILURE_TYPES
-
-CANONICAL_PHASES = {
-    "ingest",
-    "normalize",
-    "parse",
-    "analyze",
-    "generate",
-    "validate",
-    "compare",
-    "interpret",
-    "log",
-}
+from pdl.constants import CANONICAL_PHASES
 
 
 def load_invariants_yaml(path: Path) -> List[Dict[str, Any]]:
@@ -78,7 +67,11 @@ def validate_registry(payload: Dict[str, Any]) -> List[str]:
             errors.append(f"invariant[{index}] missing applies_to_phases")
         else:
             invalid_phases = sorted(
-                {phase for phase in applies_to_phases if phase not in CANONICAL_PHASES}
+                {
+                    phase
+                    for phase in applies_to_phases
+                    if phase not in set(CANONICAL_PHASES)
+                }
             )
             if invalid_phases:
                 errors.append(

--- a/generator/pdl_executor.py
+++ b/generator/pdl_executor.py
@@ -1,0 +1,128 @@
+"""
+generator/pdl_executor.py — Execute PDL-defined phases for runtime validation.
+
+Loads a PDL YAML file, resolves handler paths, executes phases in order, and
+emits a run report suitable for audit and telemetry.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib import import_module
+from importlib.util import find_spec
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+
+import json
+import yaml
+
+from generator.hashing import hash_data
+from generator.pdl_validator import validate_pdl_file
+
+
+@dataclass
+class PDLRunResult:
+    """Result payload from a PDL execution run."""
+
+    run_id: str
+    report_path: Path
+    phase_status: Dict[str, str]
+
+
+def _load_pdl(path: Path) -> Dict[str, Any]:
+    payload = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        data = json.loads(payload)
+    else:
+        data = yaml.safe_load(payload)
+    if not isinstance(data, dict):
+        raise ValueError("PDL document must parse to a mapping object")
+    return data
+
+
+def _resolve_handler(handler_path: str) -> Callable[[Dict[str, Any]], Dict[str, Any]]:
+    module_path, _, attribute = handler_path.rpartition(".")
+    if not module_path or not attribute:
+        raise ValueError(f"Invalid handler path: {handler_path!r}")
+    if find_spec(module_path) is None:
+        raise ImportError(f"Handler module not found: {module_path!r}")
+    module = import_module(module_path)
+    handler = getattr(module, attribute, None)
+    if handler is None or not callable(handler):
+        raise AttributeError(f"Handler not callable: {handler_path!r}")
+    return handler
+
+
+def _execute_phases(
+    phases: List[Dict[str, Any]],
+    *,
+    context: Dict[str, Any],
+) -> Dict[str, str]:
+    phase_status: Dict[str, str] = {}
+    for phase in phases:
+        phase_name = phase.get("name", "unknown")
+        handler_path = phase.get("handler", "")
+        handler = _resolve_handler(handler_path)
+        output = handler(context)
+        if not isinstance(output, dict):
+            raise ValueError(f"Handler output for {phase_name!r} must be a mapping.")
+        context.update(output)
+        phase_status[phase_name] = "complete"
+    return phase_status
+
+
+def execute_pdl_run(
+    *,
+    pdl_path: Path,
+    report_dir: Path,
+    run_id: str,
+    initial_context: Dict[str, Any] | None = None,
+    resolve_handlers: bool = True,
+) -> PDLRunResult:
+    """
+    Execute a PDL file and emit a run report.
+
+    Args:
+        pdl_path: Path to the PDL YAML file.
+        report_dir: Directory to emit run reports.
+        run_id: Identifier for the run.
+        initial_context: Optional starting context for phase execution.
+        resolve_handlers: Validate handler resolution before execution.
+    """
+    validate_pdl_file(pdl_path, resolve_handlers=resolve_handlers)
+    pdl_obj = _load_pdl(pdl_path)
+    phases = pdl_obj.get("phases", [])
+    if not isinstance(phases, list):
+        raise ValueError("PDL phases must be a list")
+
+    context: Dict[str, Any] = {
+        "run_id": run_id,
+        "inputs_hash": hash_data({"pdl": str(pdl_path)}),
+        "phase_status": {},
+        "artifacts": {},
+    }
+    if initial_context:
+        context.update(initial_context)
+
+    phase_status = _execute_phases(phases, context=context)
+    context["phase_status"] = phase_status
+
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_payload = {
+        "anchor": {
+            "anchor_id": "pdl_runtime_report",
+            "anchor_version": "1.0.0",
+            "scope": "runtime",
+            "owner": "generator.pdl_executor",
+            "status": "draft",
+        },
+        "run_id": run_id,
+        "pdl_path": str(pdl_path),
+        "pdl_hash": hash_data(pdl_obj),
+        "inputs_hash": context["inputs_hash"],
+        "phase_status": phase_status,
+        "outputs": context.get("artifacts", {}),
+    }
+    report_path = report_dir / f"pdl_run_{context['inputs_hash']}.json"
+    report_path.write_text(json.dumps(report_payload, indent=2), encoding="utf-8")
+    return PDLRunResult(run_id=run_id, report_path=report_path, phase_status=phase_status)

--- a/pdl/constants.py
+++ b/pdl/constants.py
@@ -1,0 +1,13 @@
+"""PDL canonical constants for phase definitions."""
+
+CANONICAL_PHASES = [
+    "ingest",
+    "normalize",
+    "parse",
+    "analyze",
+    "generate",
+    "validate",
+    "compare",
+    "interpret",
+    "log",
+]

--- a/pdl/default_pdl.py
+++ b/pdl/default_pdl.py
@@ -14,19 +14,11 @@ from importlib.util import find_spec
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
+from pdl.constants import CANONICAL_PHASES
+
 
 _DEFAULT_JSON_PATH = Path(__file__).with_name("default-pdf.json")
-_DEFAULT_PHASE_ORDER = [
-    "ingest",
-    "normalize",
-    "parse",
-    "analyze",
-    "generate",
-    "validate",
-    "compare",
-    "interpret",
-    "log",
-]
+_DEFAULT_PHASE_ORDER = list(CANONICAL_PHASES)
 _DEFAULT_PHASE_TYPES = {
     "ingest": "data",
     "normalize": "normalize",
@@ -235,7 +227,7 @@ def execute_phase(
     handler_path = phase_definitions[phase_name]["handler"]
     handler = _resolve_handler(handler_path)
     inputs = context.get("inputs") or context.get("last_output") or {}
-    phase_output = handler(inputs, context=context)
+    phase_output = handler(inputs)
     context["last_output"] = phase_output
 
     context_keys = ", ".join(sorted(context.keys()))

--- a/pdl/handlers.py
+++ b/pdl/handlers.py
@@ -10,52 +10,52 @@ from __future__ import annotations
 from typing import Any, Dict
 
 
-def ingest(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def ingest(context: Dict[str, Any]) -> Dict[str, Any]:
     """Collect and register raw inputs without interpretation."""
-    raw_payload = inputs.get("raw_payload")
+    raw_payload = context.get("raw_payload")
     return {"ingested_payload": raw_payload}
 
 
-def normalize(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def normalize(context: Dict[str, Any]) -> Dict[str, Any]:
     """Normalize inputs into canonical forms."""
-    ingested_payload = inputs.get("ingested_payload")
+    ingested_payload = context.get("ingested_payload")
     return {"normalized_payload": ingested_payload}
 
 
-def parse(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def parse(context: Dict[str, Any]) -> Dict[str, Any]:
     """Bind normalized payloads to schema-aware structures."""
-    normalized_payload = inputs.get("normalized_payload")
+    normalized_payload = context.get("normalized_payload")
     return {"parsed_payload": normalized_payload}
 
 
-def analyze(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def analyze(context: Dict[str, Any]) -> Dict[str, Any]:
     """Compute deterministic measurements from parsed artifacts."""
-    parsed_payload = inputs.get("parsed_payload")
+    parsed_payload = context.get("parsed_payload")
     metrics = {"source": parsed_payload, "metrics": {}}
     return {"analysis_metrics": metrics}
 
 
-def generate(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def generate(context: Dict[str, Any]) -> Dict[str, Any]:
     """Generate declarative outputs derived from analysis."""
-    analysis_metrics = inputs.get("analysis_metrics")
+    analysis_metrics = context.get("analysis_metrics")
     return {"draft_output": {"metrics": analysis_metrics, "artifact": {}}}
 
 
-def validate(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def validate(context: Dict[str, Any]) -> Dict[str, Any]:
     """Validate schemas and invariants on generated artifacts."""
-    draft_output = inputs.get("draft_output")
+    draft_output = context.get("draft_output")
     return {"validated_output": draft_output}
 
 
-def compare(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def compare(context: Dict[str, Any]) -> Dict[str, Any]:
     """Compare outputs against baselines deterministically."""
-    validated_output = inputs.get("validated_output")
+    validated_output = context.get("validated_output")
     return {"comparison_report": {"baseline": None, "candidate": validated_output}}
 
 
-def interpret(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def interpret(context: Dict[str, Any]) -> Dict[str, Any]:
     """Interpret measured artifacts with labeled nondeterminism."""
-    comparison_report = inputs.get("comparison_report")
+    comparison_report = context.get("comparison_report")
     return {
         "interpretation_summary": {
             "report": comparison_report,
@@ -64,11 +64,11 @@ def interpret(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) 
     }
 
 
-def log(inputs: Dict[str, Any], *, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+def log(context: Dict[str, Any]) -> Dict[str, Any]:
     """Record run metadata, hashes, and phase status."""
-    interpretation_summary = inputs.get("interpretation_summary")
-    run_id = None if context is None else context.get("run_id")
-    artifacts = None if context is None else context.get("artifacts")
+    interpretation_summary = context.get("interpretation_summary")
+    run_id = context.get("run_id")
+    artifacts = context.get("artifacts")
     return {
         "audit_log": {
             "run_id": run_id,

--- a/scripts/validate_pdl_defaults.py
+++ b/scripts/validate_pdl_defaults.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import yaml
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
+from generator.pdl_validator import validate_pdl_file
+from pdl.constants import CANONICAL_PHASES
+
+
+def main() -> int:
+    pdl_path = Path("pdl/default-pdf.yaml")
+    validate_pdl_file(pdl_path)
+    payload = yaml.safe_load(pdl_path.read_text(encoding="utf-8"))
+    phases = payload.get("phases", [])
+    phase_names = [phase.get("name") for phase in phases]
+    if phase_names != CANONICAL_PHASES:
+        raise ValueError(
+            "PDL default phases do not match canonical order: "
+            f"{phase_names} != {CANONICAL_PHASES}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_000_imports_smoke.py
+++ b/tests/test_000_imports_smoke.py
@@ -1,0 +1,7 @@
+def test_imports_smoke() -> None:
+    __import__("ai_core")
+    __import__("generator")
+    __import__("ai_evaluation")
+    __import__("ai_validation")
+    __import__("ai_recursive")
+    __import__("ai_monitoring")


### PR DESCRIPTION
### Motivation

- Provide a single, runnable PDL-driven entrypoint and reproducible demo run that uses a canonical phase ordering.
- Centralize the canonical phase ordering to avoid divergence between code and `pdl/default-pdf.yaml`.
- Allow runtime execution and handler resolution checks of PDL documents to produce audit-friendly run reports.
- Keep distribution archives free of build artifacts and caches by expanding `.gitignore` to exclude common build/coverage outputs.

### Description

- Add a PDL runtime executor `generator/pdl_executor.py` that loads a PDL file, resolves/executes handlers, and emits a JSON run report via `execute_pdl_run`.
- Introduce `pdl/constants.py` containing `CANONICAL_PHASES` and update `pdl/default_pdl.py`, `pdl/handlers.py`, and `generator/invariant_registry.py` to consume it, and add a `--pdl` CLI flag in `generator/main.py` to run the executor.
- Improve PDL validation in `generator/pdl_validator.py` with optional handler resolution (`--resolve-handlers` / `--no-resolve-handlers`) and add `scripts/validate_pdl_defaults.py` plus tests `tests/test_000_imports_smoke.py` and updated `tests/test_pdl_default_phases.py` to assert schema validity and canonical ordering.
- Update docs and quickstart (`README.md`, `docs/QUICKSTART.md`) to document the canonical CLI `python3 generator/main.py --pdl pdl/default-pdf.yaml --demo`, add CI validation/compile steps in `.github/workflows/python-tests.yml`, and expand `.gitignore` to exclude `dist/`, `.mypy_cache/`, coverage artifacts, and other caches.

### Testing

- No automated tests were executed locally as part of this change (configuration and feature additions only).
- CI workflow was updated to compile Python sources via `python -m compileall .` before validation steps.
- CI will run PDL validation commands `python -m generator.pdl_validator pdl/default-pdf.yaml --resolve-handlers`, `python -m generator.pdl_validator pdl/example_full_9_phase.yaml --resolve-handlers`, and `python scripts/validate_pdl_defaults.py` to verify schema and canonical phase order.
- CI will run the test suite via `pytest -q tests` (results to be produced by CI).