### PR TITLE
Polish README and runbook: align quick start with canonical runbook and PDL demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,27 +82,29 @@ Author: **Tommy Raven (Thomas Byers)**
 ## ▶️ Canonical Runbook
 
 **Primary entrypoint (how to run + expected outputs):**  
-docs/RUNBOOK.md
+[docs/RUNBOOK.md](docs/RUNBOOK.md)
 
 Other docs are secondary/overview and should defer to the canonical runbook above.
 
 ---
 
-## ⚡ Quick Start (Canonical PDL Run)
+## ⚡ Quick Start (Canonical, Deterministic)
 
-Run the runtime-driven PDL flow with the canonical 9-phase definition:
+Run the canonical deterministic demo flow from the repo root:
 
 ```bash
-python3 generator/main.py --pdl pdl/default-pdf.yaml --demo
+python3 -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas
+python3 generator/main.py --demo --no-refine
 ```
 
-> **Heads-up:** this repo intentionally vendors in-repo `yaml/` and `jsonschema/` modules that can shadow similarly named third-party packages. This is a deliberate design choice to keep schema handling deterministic within the repo, so ensure your environment resolves these local modules when running the Quick Start.
+> **Heads-up:** this repo intentionally vendors in-repo `yaml/` and `jsonschema/`
+> modules that can shadow similarly named third-party packages. This is a
+> deliberate design choice to keep schema handling deterministic within the
+> repo, so ensure your environment resolves these local modules when running
+> the Quick Start.
 
-Expected outputs (including the PDL run report) land in:
-
-```
-data/outputs/demo_run/
-```
+Expected outputs land in `data/outputs/demo_run/`. See the runbook for a
+complete, drift-free list of artifacts and optional PDL runtime commands.
 
 See [CHANGELOG.md](CHANGELOG.md) for the v1.2.0 release notes.
 
@@ -272,8 +274,7 @@ Run the PDL-driven runtime pipeline from the repo root:
 python3 generator/main.py --pdl pdl/default-pdf.yaml --demo
 ```
 
-Outputs land in `data/outputs/demo_run` and include:
-- PDL run report (`pdl_runs/*.json`)
+Outputs land in `data/outputs/demo_run/pdl_runs/` as `pdl_run_<inputs_hash>.json`.
 
 ---
 
@@ -296,12 +297,12 @@ Outputs land in `data/outputs/demo_run` and include:
 
 ### Clone the Repository
 
-    git clone https://github.com/Tommy-Raven/SSWG-mvm1.0.git
-    cd SSWG-mvm1.0
+    git clone https://github.com/Tommy-Raven/sswg-mvm1.0.git
+    cd sswg-mvm1.0
 
 ### Install Dependencies
-    use `pipx` if using virtual container
-    `pip install -r REQUIREMENTS.txt`
+    # use pipx if you prefer isolated environments
+    pip install -r REQUIREMENTS.txt
 
 ### Validate the canonical PDL (required before runs)
 
@@ -309,7 +310,7 @@ Outputs land in `data/outputs/demo_run` and include:
 
 ### Run the Generator (exact entry path)
 
-    python3 generator/main.py --pdl pdl/default-pdf.yaml --demo
+    python3 generator/main.py --demo --no-refine
 
 Artifacts will be created under:
 
@@ -349,7 +350,7 @@ Test coverage includes:
 AI Researcher • Workflow Engineer • Python Developer  
 © Raven Recordings, LLC 2025  
 
-GitHub: **https://github.com/Tommy-Raven/SSWG-mvm1.0**  
+GitHub: **https://github.com/Tommy-Raven/sswg-mvm1.0**  
 Pronouns: *Apache / Helicopter*  
 Fun fact: *Not actually an Apache helicopter — but thriving anyway.*  
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,10 +1,10 @@
-# Deterministic Run Recipe (sswg/mvm)
+# Deterministic Runbook (sswg/mvm)
 
 **Canonical status (primary entrypoint for how to run + expected outputs):** This runbook is the single canonical guide for deterministic, audit-ready runs of the sswg/mvm pipeline. Other docs are secondary/overview and should defer here to avoid drift.
 
 ## Deterministic Run Recipe
 
-### 1) Validate the PDL phase set
+### 1) Validate the PDL phase set (required)
 
 **Command**
 ```bash
@@ -28,43 +28,48 @@ python3 -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas
 
 **Command**
 ```bash
-python3 generator/main.py \
-  --workflow-json data/templates/campfire_workflow.json \
-  --no-refine \
-  --out-dir data/outputs
+python3 generator/main.py --demo --no-refine
 ```
 
 **Inputs**
-- `data/templates/campfire_workflow.json` (seed workflow)
+- `data/templates/campfire_workflow.json` (seed workflow used by `--demo`)
 - `schemas/` (workflow schema validation)
 
 **Expected artifacts (paths, filenames, contents)**
-- `data/outputs/<workflow_id>.json`
-  - Full workflow payload (phases, modules, evaluation summaries, dependency graph metadata).
-- `data/outputs/<workflow_id>.md`
+- `data/outputs/demo_run/workflow_<workflow_id>_<timestamp>.json`
+  - Workflow payload (phases, modules, evaluation summaries, dependency graph metadata).
+- `data/outputs/demo_run/workflow_<workflow_id>_<timestamp>.md`
   - Human-readable phase/task summary with evaluation notes.
-- `data/outputs/workflow_<workflow_id>_<timestamp>.json`
-  - Timestamped visualization JSON export of the workflow payload.
-- `data/outputs/workflow_<workflow_id>_<timestamp>.md`
-  - Timestamped visualization Markdown export (phase overview and metadata).
-- `data/outputs/workflow_graph_<timestamp>.dot`
+- `data/outputs/demo_run/workflow_graph_<timestamp>.dot`
   - Graphviz DOT file capturing dependency nodes and edges.
 
 > Determinism note: `--no-refine` disables the recursive refinement step to keep the run deterministic.
 
 ---
 
-## Expected Outputs Checklist
+### 3) (Optional) Run the PDL runtime demo
 
-### data/outputs/ (repository snapshots)
-- [ ] `data/outputs/meta_template_20251203230038.md`
-- [ ] `data/outputs/training_template_20251207034010.md`
-- [ ] `data/outputs/training_template_20251207034925.md`
-- [ ] `data/outputs/unnamed_workflow.md`
-- [ ] `data/outputs/workflow_001.md`
+**Command**
+```bash
+python3 generator/main.py --pdl pdl/default-pdf.yaml --demo
+```
 
-### Benchmark / profiling artifacts
-- [ ] `artifacts/performance/benchmarks_20251227_090721.json` (benchmark results)
-- [ ] `data/profiling/workflow_profiling_2025-12-27.json` (profiling summary)
-- [ ] `data/profiling/campfire_workflow/` (profiling run directory)
-- [ ] `data/profiling/technical_procedure_template/` (profiling run directory)
+**Inputs**
+- `pdl/default-pdf.yaml` (PDL demo configuration)
+- `schemas/` (PDL schema validation)
+
+**Expected artifacts**
+- `data/outputs/demo_run/pdl_runs/pdl_run_<inputs_hash>.json`
+  - PDL runtime report containing phase status, inputs hash, and artifact references.
+
+---
+
+## Expected Outputs Checklist (drift-free patterns)
+
+### Deterministic workflow run
+- [ ] `data/outputs/demo_run/workflow_<workflow_id>_<timestamp>.json`
+- [ ] `data/outputs/demo_run/workflow_<workflow_id>_<timestamp>.md`
+- [ ] `data/outputs/demo_run/workflow_graph_<timestamp>.dot`
+
+### Optional PDL runtime run
+- [ ] `data/outputs/demo_run/pdl_runs/pdl_run_<inputs_hash>.json`


### PR DESCRIPTION
### Motivation
- Ensure `README.md` and `docs/RUNBOOK.md` are the golden path and drift-free documentation for running the canonical deterministic pipeline.
- Make the Quick Start explicit and deterministic by validating the PDL before running the demo and by recommending `--no-refine` for reproducible runs.
- Surface the canonical PDL runtime demo and its expected artifact locations to avoid confusion about where reports are written.
- Normalize repository naming/casing and clone instructions for consistency across docs.

### Description
- Updated `README.md` to link to `docs/RUNBOOK.md`, recommend `python3 -m generator.pdl_validator pdl/example_full_9_phase.yaml schemas`, and recommend `python3 generator/main.py --demo --no-refine` as the deterministic quick start.
- Revised `docs/RUNBOOK.md` to mark the PDL validation step as required, replace the multi-line demo invocation with `python3 generator/main.py --demo --no-refine`, and add an optional PDL runtime demo section that documents `data/outputs/demo_run/pdl_runs/pdl_run_<inputs_hash>.json` as the expected report artifact.
- Normalized repository references and clone instructions to use the lowercase `sswg-mvm1.0` slug and cleaned up install/run examples in both files.
- Changes committed to the branch (files modified: `README.md`, `docs/RUNBOOK.md`).

### Testing
- ⚠️ No automated tests were run because these are documentation-only changes.