### PR TITLE
Clarify always-on vs promotion gates in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,6 +342,21 @@ Test coverage includes:
 - `make gates` for audit readiness and determinism validation
 - `make preflight` for a local CI-equivalent sweep
 
+### ✅ Always-on correctness gates (minimum required)
+
+These gates are mandatory for any run or change set and enforce baseline correctness:
+
+- Schema validation (PDL wrapper + phase schemas)
+- Phase validation and invariants validation
+- Reproducibility validation for deterministic phases
+
+### 🧪 Optional research/promotion gates (situational)
+
+These gates are used for research readiness, audit bundles, and promotion decisions:
+
+- `make gates` for audit readiness + determinism evidence
+- Promotion readiness checks (e.g., audit bundle generation in `scripts/run_promotion_readiness.py`)
+
 ---
 
 ## 👤 Author & Contact


### PR DESCRIPTION
### Motivation

- Clarify separation between mandatory baseline validation gates and optional research/promotion gates to reduce confusion about required checks.
- Document the minimal, always-on correctness requirements that must be enforced before runs or change sets.
- Provide guidance linking audit and promotion tooling for situational use.

### Description

- Added a `Always-on correctness gates` section to `README.md` enumerating mandatory gates: `Schema validation`, `Phase validation and invariants validation`, and `Reproducibility validation`.
- Added an `Optional research/promotion gates` section pointing to situational checks such as `make gates` and the promotion readiness script `scripts/run_promotion_readiness.py`.
- Committed the change to `README.md` and created the pull request.

### Testing

- No automated unit or integration tests were run because this is a documentation-only change.
- The git commit completed successfully and a PR was opened with the documentation update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69568a2e8ff4832895f6f17ef4ef4b4f)