### PR TITLE
Golden-path CLI + benchmark repeats, workload characterization, and variance reporting

### DIFF
--- a/cli/cli.py
+++ b/cli/cli.py
@@ -13,6 +13,7 @@ from argparse import Namespace
 from pathlib import Path
 from subprocess import run as subprocess_run
 from typing import Sequence
+import sys
 
 from pdl.default_pdl import (
     execute_phase as pdl_execute_phase,
@@ -108,6 +109,93 @@ def cmd_request_merge(args: Namespace) -> None:
         print(f"[CLI] Merge failed: {args.branch} → {target} " f"(exit={exit_code})")
 
 
+def _require_paths(paths: Sequence[Path]) -> None:
+    missing = [str(path) for path in paths if not path.exists()]
+    if missing:
+        raise FileNotFoundError(f"[CLI] Missing required paths: {', '.join(missing)}")
+
+
+def cmd_init(args: Namespace) -> None:
+    """
+    Initialize deterministic run prerequisites for the golden path.
+
+    Args:
+        args: Parsed CLI arguments containing 'out_dir' and 'audit_dir'.
+    """
+    _require_paths([args.pdl_path, args.schema_dir])
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    args.audit_dir.mkdir(parents=True, exist_ok=True)
+    args.audit_failures_dir.mkdir(parents=True, exist_ok=True)
+    print(f"[CLI] Initialized output dir: {args.out_dir}")
+    print(f"[CLI] Initialized audit dir: {args.audit_dir}")
+
+
+def cmd_run(args: Namespace) -> None:
+    """
+    Run deterministic workflow execution for the golden path.
+
+    Args:
+        args: Parsed CLI arguments containing 'no_refine' and 'no_history'.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "generator.main",
+        "--demo",
+    ]
+    if not args.refine:
+        cmd.append("--no-refine")
+    if not args.history:
+        cmd.append("--no-history")
+    exit_code = run(cmd)
+    if exit_code != 0:
+        raise SystemExit(exit_code)
+
+
+def cmd_validate(args: Namespace) -> None:
+    """
+    Validate the canonical PDL phase set for the golden path.
+
+    Args:
+        args: Parsed CLI arguments containing 'pdl_path' and 'schema_dir'.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "generator.pdl_validator",
+        str(args.pdl_path),
+        str(args.schema_dir),
+    ]
+    exit_code = run(cmd)
+    if exit_code != 0:
+        raise SystemExit(exit_code)
+
+
+def cmd_bundle(args: Namespace) -> None:
+    """
+    Build the audit bundle for the golden path run.
+
+    Args:
+        args: Parsed CLI arguments containing 'run_id', 'audit_spec', and 'audit_dir'.
+    """
+    cmd = [
+        sys.executable,
+        "-m",
+        "scripts.audit_bundle_builder",
+        "--audit-spec",
+        str(args.audit_spec),
+        "--run-id",
+        args.run_id,
+        "--bundle-dir",
+        str(args.audit_dir),
+        "--manifest-path",
+        str(args.manifest_path),
+    ]
+    exit_code = run(cmd)
+    if exit_code != 0:
+        raise SystemExit(exit_code)
+
+
 def build_parser() -> argparse.ArgumentParser:
     """
     Build the CLI argument parser with all SSWG commands.
@@ -150,6 +238,108 @@ def build_parser() -> argparse.ArgumentParser:
     )
     merge.add_argument("branch", help="Branch name to merge")
     merge.set_defaults(func=cmd_request_merge)
+
+    init = subparsers.add_parser(
+        "init",
+        help="Initialize deterministic run prerequisites",
+    )
+    init.add_argument(
+        "--pdl-path",
+        type=Path,
+        default=Path("pdl/example_full_9_phase.yaml"),
+        help="Path to the canonical PDL file.",
+    )
+    init.add_argument(
+        "--schema-dir",
+        type=Path,
+        default=Path("schemas"),
+        help="Directory containing PDL schemas.",
+    )
+    init.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("data/outputs/demo_run"),
+        help="Output directory for deterministic run artifacts.",
+    )
+    init.add_argument(
+        "--audit-dir",
+        type=Path,
+        default=Path("artifacts/audit"),
+        help="Audit bundle directory.",
+    )
+    init.add_argument(
+        "--audit-failures-dir",
+        type=Path,
+        default=Path("artifacts/audit/failures"),
+        help="Directory for audit failure artifacts.",
+    )
+    init.set_defaults(func=cmd_init)
+
+    run_cmd = subparsers.add_parser(
+        "run",
+        help="Run deterministic workflow generation",
+    )
+    run_cmd.add_argument(
+        "--refine",
+        action="store_true",
+        default=False,
+        help="Enable recursive refinement (non-deterministic).",
+    )
+    run_cmd.add_argument(
+        "--history",
+        action="store_true",
+        default=False,
+        help="Enable history recording (non-deterministic).",
+    )
+    run_cmd.set_defaults(func=cmd_run)
+
+    validate = subparsers.add_parser(
+        "validate",
+        help="Validate the canonical PDL phase set",
+    )
+    validate.add_argument(
+        "--pdl-path",
+        type=Path,
+        default=Path("pdl/example_full_9_phase.yaml"),
+        help="Path to the canonical PDL file.",
+    )
+    validate.add_argument(
+        "--schema-dir",
+        type=Path,
+        default=Path("schemas"),
+        help="Directory containing PDL schemas.",
+    )
+    validate.set_defaults(func=cmd_validate)
+
+    bundle = subparsers.add_parser(
+        "bundle",
+        help="Build the audit bundle for the deterministic run",
+    )
+    bundle.add_argument(
+        "--audit-spec",
+        type=Path,
+        default=Path("governance/audit_bundle_spec.json"),
+        help="Audit bundle specification path.",
+    )
+    bundle.add_argument(
+        "--audit-dir",
+        type=Path,
+        default=Path("artifacts/audit"),
+        help="Audit bundle directory.",
+    )
+    bundle.add_argument(
+        "--manifest-path",
+        type=Path,
+        default=Path("artifacts/audit/audit_bundle_manifest.json"),
+        help="Audit bundle manifest path.",
+    )
+    bundle.add_argument(
+        "--run-id",
+        type=str,
+        default="golden-path",
+        help="Run identifier for the audit bundle.",
+    )
+    bundle.set_defaults(func=cmd_bundle)
 
     return parser
 

--- a/docs/PERFORMANCE_BENCHMARKS.md
+++ b/docs/PERFORMANCE_BENCHMARKS.md
@@ -57,6 +57,10 @@ ranges live in [`ai_memory/benchmark_tracker.py`](../ai_memory/benchmark_tracker
 Environment references (hardware + software baselines, container specs) live
 under [`reproducibility/`](../reproducibility/) to align the run context.
 
+Benchmark reports now include:
+- repeated-run variance summaries (local CI runs five repeats)
+- workload characterization for workflow size, recursion depth, and dependency density
+
 ## ✅ Latest Measured Results (2025-12-27T09:07:21Z)
 
 **Raw results:** [`artifacts/performance/benchmarks_20251227_090721.json`](../artifacts/performance/benchmarks_20251227_090721.json)

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -2,6 +2,16 @@
 
 **Canonical status (primary entrypoint for how to run + expected outputs):** This runbook is the single canonical guide for deterministic, audit-ready runs of the sswg/mvm pipeline. Other docs are secondary/overview and should defer here to avoid drift.
 
+## Golden path CLI (single deterministic flow)
+
+Run the canonical golden path with the CLI in a single, deterministic sequence:
+
+```bash
+sswg init && sswg run && sswg validate && sswg bundle
+```
+
+Defaults are deterministic: `sswg run` disables recursive refinement and history unless explicitly overridden.
+
 ## Deterministic Run Recipe
 
 ### 1) Validate the PDL phase set (required)

--- a/scripts/local_ci.py
+++ b/scripts/local_ci.py
@@ -160,7 +160,7 @@ def task_recursive_benchmark() -> TaskResult:
     """
     return run_command(
         "scripts.benchmark_pipeline",
-        [sys.executable, "scripts/benchmark_pipeline.py"],
+        [sys.executable, "-m", "scripts.benchmark_pipeline", "--repeats", "5"],
     )
 
 


### PR DESCRIPTION
### Motivation
- Provide a single, deterministic golden-path flow that can be run end-to-end (`sswg init && sswg run && sswg validate && sswg bundle`).
- Make `sswg run` deterministic by default (disable refinement/history unless explicitly enabled) to support reproducible demo runs.
- Capture run-to-run variance and add structural workload characterization for performance benchmarks to support distribution-aware regression detection.
- Ensure benchmark pipeline is invoked as a module for reliable module resolution in scripted local CI runs.

### Description
- Add CLI commands in `cli/cli.py`: `init`, `run`, `validate`, and `bundle`, with `cmd_init`, `cmd_run`, `cmd_validate`, and `cmd_bundle` wiring to `generator.main`, `generator.pdl_validator`, and `scripts.audit_bundle_builder` via `sys.executable -m` and helper `_require_paths` for preconditions; `run` exposes `--refine` and `--history` (both opt-in).
- Extend `scripts/benchmark_pipeline.py` with `--repeats` and `--workload-templates`, workload characterization helpers (`_characterize_workflow`, `_characterize_workloads`, `_dependency_density`, `_count_tasks`), variance helpers (`_flatten_metrics`, `_variance_summary`, `_build_variance_report`, `_sample_run`), and a loop to produce `run_samples` and `variance_report` in the output JSON.
- Update `scripts/local_ci.py` to invoke the benchmark pipeline as a module (`sys.executable -m scripts.benchmark_pipeline`) and run it with `--repeats 5` for local CI.
- Document the golden path in `docs/RUNBOOK.md` and note expanded benchmark report contents in `docs/PERFORMANCE_BENCHMARKS.md`.

### Testing
- No automated test suites were executed against these changes as part of this rollout.
- (No automated failures were reported because tests were not invoked.)
