### PR TITLE
Add benchmark-aware audit bundle outputs, reference loop, and CLI/packaging updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ data/workflows/sanity_test_*.json
 # MVM generated outputs
 # -------------------------
 # Ignore all new MVM outputs by default
+data/
+!data/
+!data/outputs/
 data/outputs/*
 
 # Keep these canonical artifacts tracked
@@ -64,6 +67,7 @@ data/outputs/*
 !data/outputs/training_template_20251207034925.md
 !data/outputs/unnamed_workflow.md
 !data/outputs/workflow_001.md
-data/
+!data/outputs/__init__.py
+!data/outputs/audit_bundle.py
 build/
 dist/

--- a/ai_evaluation/__init__.py
+++ b/ai_evaluation/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from .checkpoints import EvaluationCheckpoint, EvaluationCheckpointer
 from .evaluation_engine import evaluate_workflow_quality
 from .semantic_analysis import SemanticAnalyzer
+from .verity_tensor import compute_verity
 from .scoring_adapter import ScoreAdapter
 
 __all__ = [
@@ -22,6 +23,7 @@ __all__ = [
     "ScoreAdapter",
     "EvaluationCheckpoint",
     "EvaluationCheckpointer",
+    "compute_verity",
 ]
 
 

--- a/ai_evaluation/verity_tensor.py
+++ b/ai_evaluation/verity_tensor.py
@@ -38,3 +38,18 @@ def summarize_tensor_inputs(
         "entropy": entropy,
         "verity_tensor": tensor,
     }
+
+
+def compute_verity(
+    *, semantic_score: float, det_score: float, entropy: float
+) -> Dict[str, Any]:
+    """
+    Compute a verity payload with the canonical tensor output.
+    """
+    verity = compute_verity_tensor(semantic_score, det_score, entropy)
+    return {
+        "semantic": semantic_score,
+        "determinism": det_score,
+        "entropy": entropy,
+        "verity": verity,
+    }

--- a/ai_memory/__init__.py
+++ b/ai_memory/__init__.py
@@ -9,12 +9,14 @@ from .memory_store import MemoryStore
 from .feedback_integrator import FeedbackIntegrator
 from .anomaly_detector import AnomalyDetector
 from .benchmark_tracker import BenchmarkTracker
+from .entropy_controller import verify_entropy_budget
 
 __all__ = [
     "MemoryStore",
     "FeedbackIntegrator",
     "AnomalyDetector",
     "BenchmarkTracker",
+    "verify_entropy_budget",
 ]
 
 

--- a/ai_memory/entropy_controller.py
+++ b/ai_memory/entropy_controller.py
@@ -40,3 +40,28 @@ class EntropyController:
             "mean_entropy": round(mean, 4),
             "remaining_budget": round(self.remaining_budget(), 4),
         }
+
+
+def verify_entropy_budget(
+    *,
+    controller: EntropyController | None = None,
+    entropy_values: list[float] | None = None,
+    max_entropy: float = 1.0,
+) -> Dict[str, Any]:
+    """
+    Validate entropy totals against the configured budget.
+    """
+    if controller is None:
+        controller = EntropyController(max_entropy=max_entropy)
+        for value in entropy_values or []:
+            controller.log_entropy(value)
+
+    summary = controller.summary()
+    within_budget = summary["total_entropy"] <= max_entropy
+    return {
+        "total_entropy": summary["total_entropy"],
+        "mean_entropy": summary["mean_entropy"],
+        "remaining_budget": summary["remaining_budget"],
+        "max_entropy": round(max_entropy, 4),
+        "within_budget": within_budget,
+    }

--- a/cli/cli.py
+++ b/cli/cli.py
@@ -190,6 +190,8 @@ def cmd_bundle(args: Namespace) -> None:
         str(args.audit_dir),
         "--manifest-path",
         str(args.manifest_path),
+        "--benchmark-log",
+        str(args.benchmark_log),
     ]
     exit_code = run(cmd)
     if exit_code != 0:
@@ -203,7 +205,10 @@ def build_parser() -> argparse.ArgumentParser:
     Returns:
         Configured CLI parser.
     """
-    parser = argparse.ArgumentParser(prog="sswg", description="SSWG project CLI")
+    parser = argparse.ArgumentParser(
+        prog="sswg",
+        description="sswg/mvm Golden Path CLI (init → run → validate → bundle)",
+    )
     subparsers = parser.add_subparsers(dest="cmd")
 
     # Phase command
@@ -241,7 +246,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     init = subparsers.add_parser(
         "init",
-        help="Initialize deterministic run prerequisites",
+        help="Initialize golden path prerequisites (deterministic setup)",
     )
     init.add_argument(
         "--pdl-path",
@@ -277,7 +282,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     run_cmd = subparsers.add_parser(
         "run",
-        help="Run deterministic workflow generation",
+        help="Run the deterministic golden path workflow generation",
     )
     run_cmd.add_argument(
         "--refine",
@@ -295,7 +300,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     validate = subparsers.add_parser(
         "validate",
-        help="Validate the canonical PDL phase set",
+        help="Validate the canonical PDL phase set for the golden path",
     )
     validate.add_argument(
         "--pdl-path",
@@ -313,7 +318,7 @@ def build_parser() -> argparse.ArgumentParser:
 
     bundle = subparsers.add_parser(
         "bundle",
-        help="Build the audit bundle for the deterministic run",
+        help="Build the audit bundle for the golden path run",
     )
     bundle.add_argument(
         "--audit-spec",
@@ -332,6 +337,12 @@ def build_parser() -> argparse.ArgumentParser:
         type=Path,
         default=Path("artifacts/audit/audit_bundle_manifest.json"),
         help="Audit bundle manifest path.",
+    )
+    bundle.add_argument(
+        "--benchmark-log",
+        type=Path,
+        default=Path("artifacts/performance/benchmarks_20251227_090721.json"),
+        help="Benchmark log path used for audit metrics.",
     )
     bundle.add_argument(
         "--run-id",

--- a/config/setup.py
+++ b/config/setup.py
@@ -5,11 +5,11 @@
 from setuptools import setup, find_packages
 
 setup(
-    name="ai-instructional-workflow-generator",  # Replace if needed
-    version="0.1.0",
+    name="sswg-mvm",
+    version="1.3.0+mvm",
     author="Tommy Byers (Tommy-Raven)",
     author_email="your.email@example.com",
-    description="Recursive AI Instructional Workflow Generator (Grimoire v5.0)",
+    description="sswg mvm is the minimum viable model for the sswg workflow generation system.",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/Tommy-Raven/sswg-mvm1.0",
@@ -31,6 +31,10 @@ setup(
             "ai_validation.*",
             "ai_visualization",
             "ai_visualization.*",
+            "cli",
+            "cli.*",
+            "data",
+            "data.*",
             "generator",
             "generator.*",
             "modules",
@@ -41,7 +45,7 @@ setup(
             "schemas",
         ]
     ),
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     install_requires=[
         "networkx>=3.2",
         "pyyaml>=6.0",
@@ -58,7 +62,7 @@ setup(
     },
     entry_points={
         "console_scripts": [
-            "aiwf = cli:main",  # Assuming cli.py defines a main() function
+            "sswg = cli.cli:main",
         ],
     },
     include_package_data=True,

--- a/data/outputs/__init__.py
+++ b/data/outputs/__init__.py
@@ -1,0 +1,7 @@
+"""Output helpers and reporting modules for sswg/mvm."""
+
+from __future__ import annotations
+
+__all__ = [
+    "audit_bundle",
+]

--- a/data/outputs/audit_bundle.py
+++ b/data/outputs/audit_bundle.py
@@ -1,0 +1,135 @@
+"""Audit bundle outputs for the sswg/mvm golden path."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+from generator.audit_bundle import build_bundle as _build_bundle
+from generator.audit_bundle import load_audit_spec
+from generator.audit_bundle import validate_bundle as _validate_bundle
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    return _sha256_bytes(path.read_bytes())
+
+
+def _extract_series(payload: Dict[str, Any], key: str) -> List[float]:
+    if isinstance(payload.get(key), list):
+        return [float(value) for value in payload[key]]
+    history = payload.get("history")
+    if isinstance(history, dict) and isinstance(history.get(key), list):
+        return [float(value) for value in history[key]]
+    metrics = payload.get("metrics")
+    if isinstance(metrics, dict) and isinstance(metrics.get(key), list):
+        return [float(value) for value in metrics[key]]
+    return []
+
+
+def _mean(values: Iterable[float]) -> float:
+    values_list = list(values)
+    if not values_list:
+        return 0.0
+    return round(sum(values_list) / len(values_list), 4)
+
+
+def _entropy_totals(values: Iterable[float]) -> Dict[str, float]:
+    values_list = list(values)
+    return {
+        "total": round(sum(values_list), 4),
+        "mean": _mean(values_list),
+    }
+
+
+def _manifest_checksum(manifest: Dict[str, Any]) -> str:
+    payload = {key: value for key, value in manifest.items() if key != "checksum"}
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode(
+        "utf-8"
+    )
+    return _sha256_bytes(encoded)
+
+
+def _load_benchmark_log(path: Path) -> Dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_audit_bundle(
+    *,
+    spec: Dict[str, Any],
+    run_id: str,
+    bundle_dir: Path,
+    manifest_path: Path,
+    benchmark_log_path: Path,
+) -> Dict[str, Any]:
+    """Create a bundle of audit artifacts with benchmark-derived metrics."""
+    if not benchmark_log_path.exists():
+        raise FileNotFoundError(f"Benchmark log missing: {benchmark_log_path}")
+
+    base_manifest = _build_bundle(
+        spec=spec,
+        run_id=run_id,
+        bundle_dir=bundle_dir,
+        manifest_path=manifest_path,
+    )
+
+    benchmark_log = _load_benchmark_log(benchmark_log_path)
+    entropy_values = _extract_series(benchmark_log, "entropy")
+    verity_values = _extract_series(benchmark_log, "verity")
+
+    manifest = dict(base_manifest)
+    anchor = dict(manifest.get("anchor", {}))
+    anchor["owner"] = "data.outputs.audit_bundle"
+    manifest["anchor"] = anchor
+    manifest["timestamp"] = _utc_timestamp()
+    manifest["benchmark_log"] = {
+        "path": str(benchmark_log_path),
+        "checksum": _sha256_file(benchmark_log_path),
+    }
+    manifest["entropy_totals"] = _entropy_totals(entropy_values)
+    manifest["verity_mean"] = _mean(verity_values)
+    manifest["checksum"] = _manifest_checksum(manifest)
+
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    return manifest
+
+
+def validate_audit_bundle(manifest: Dict[str, Any]) -> Dict[str, Any]:
+    """Validate audit bundle manifest completeness and integrity."""
+    results = _validate_bundle(manifest)
+    errors = list(results.get("errors", []))
+
+    required_fields = ["timestamp", "entropy_totals", "verity_mean", "checksum"]
+    for field in required_fields:
+        if field not in manifest:
+            errors.append({"type": "missing_field", "field": field})
+
+    benchmark = manifest.get("benchmark_log", {})
+    benchmark_path = Path(benchmark.get("path", "")) if benchmark else None
+    if benchmark_path and benchmark_path.exists():
+        checksum = benchmark.get("checksum")
+        if checksum and checksum != _sha256_file(benchmark_path):
+            errors.append({"type": "benchmark_checksum_mismatch"})
+    else:
+        errors.append({"type": "benchmark_log_missing"})
+
+    status = "pass" if not errors else "fail"
+    return {"status": status, "errors": errors}
+
+
+__all__ = [
+    "build_audit_bundle",
+    "load_audit_spec",
+    "validate_audit_bundle",
+]

--- a/generator/reference_loop.py
+++ b/generator/reference_loop.py
@@ -1,0 +1,89 @@
+"""Reference loop orchestrator for sswg/mvm runs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterable, Optional
+
+from ai_core.orchestrator import Orchestrator, RunContext
+from ai_evaluation.verity_tensor import compute_verity
+from ai_memory.benchmark_evolution import BenchmarkEvolution
+from ai_memory.entropy_controller import EntropyController, verify_entropy_budget
+
+
+@dataclass(frozen=True)
+class ReferenceLoopResult:
+    run_id: str
+    run_output: Dict[str, Any]
+    entropy_summary: Dict[str, Any]
+    benchmark_summary: Dict[str, Any]
+    convergence_summary: Dict[str, Any]
+
+
+def run_reference_loop(
+    *,
+    workflow_source: Dict[str, Any] | Path,
+    run_id: str,
+    phases: Optional[Iterable[str]] = None,
+    validate_after: bool = True,
+    runner: Optional[Callable[..., Any]] = None,
+    runner_kwargs: Optional[Dict[str, Any]] = None,
+    iterations: int = 1,
+    semantic_score: float = 0.0,
+    determinism_score: float = 1.0,
+    entropy_per_iteration: float = 0.0,
+    entropy_budget: float = 1.0,
+) -> ReferenceLoopResult:
+    """Run a bounded reference loop with orchestration wiring."""
+    orchestrator = Orchestrator()
+    benchmark = BenchmarkEvolution()
+    entropy_controller = EntropyController(max_entropy=entropy_budget)
+    run_payload: Dict[str, Any] = {}
+
+    for _ in range(max(1, iterations)):
+        context = RunContext(
+            workflow_source=workflow_source,
+            phases=phases,
+            validate_after=validate_after,
+            runner=runner,
+            runner_kwargs=runner_kwargs or {},
+        )
+        run_result = orchestrator.run_mvm(context)
+        run_payload = {
+            "workflow": run_result.workflow_data,
+            "phase_status": run_result.phase_status,
+        }
+
+        verity_payload = compute_verity(
+            semantic_score=semantic_score,
+            det_score=determinism_score,
+            entropy=entropy_per_iteration,
+        )
+        benchmark.log_cycle(
+            verity=verity_payload["verity"],
+            entropy=entropy_per_iteration,
+            determinism=determinism_score,
+        )
+        entropy_controller.log_entropy(entropy_per_iteration)
+
+    entropy_summary = verify_entropy_budget(
+        controller=entropy_controller,
+        max_entropy=entropy_budget,
+    )
+    benchmark_summary = benchmark.statistical_summary()
+    convergence_summary = benchmark.convergence_summary()
+
+    return ReferenceLoopResult(
+        run_id=run_id,
+        run_output=run_payload,
+        entropy_summary=entropy_summary,
+        benchmark_summary=benchmark_summary,
+        convergence_summary=convergence_summary,
+    )
+
+
+__all__ = [
+    "ReferenceLoopResult",
+    "run_reference_loop",
+]

--- a/project.toml
+++ b/project.toml
@@ -1,13 +1,13 @@
 [anchor]
 anchor_id = "project-toml"
-anchor_version = "1.2.0mvm"
+anchor_version = "1.3.0+mvm"
 scope = "repo"
 owner = "Raven Recordings"
 status = "draft"
 
 [project]
 name = "sswg-mvm"
-version = "1.2.0mvm"
+version = "1.3.0+mvm"
 status = "active"
 release_stage = "pre-release"
 description = "sswg mvm is the minimum viable model for the sswg workflow generation system."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,16 +1,37 @@
 [anchor]
 anchor_id = "project-toml"
-anchor_version = "1.2.0+mvm"
+anchor_version = "1.3.0+mvm"
 scope = "repo"
 owner = "Raven Recordings"
 status = "draft"
 
 [project]
 name = "sswg-mvm"
-version = "1.2.0+mvm"
+version = "1.3.0+mvm"
+description = "sswg mvm is the minimum viable model for the sswg workflow generation system."
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+  "networkx>=3.2",
+  "pyyaml>=6.0",
+  "graphviz>=0.20.1",
+  "jsonschema>=4.19",
+  "sentence-transformers>=3.0.1",
+]
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=8.0",
+  "flake8>=7.0",
+  "black>=24.1",
+]
+
+[project.scripts]
+sswg = "cli.cli:main"
+
+[tool.sswg]
 status = "active"
 release_stage = "pre-release"
-description = "sswg mvm is the minimum viable model for the sswg workflow generation system."
 
 [system]
 component = "sswg"
@@ -26,3 +47,7 @@ terms = "TERMS_OF_USE.md"
 [repository]
 url = "https://github.com/Tommy-Raven/SSWG-mvm1.0"
 default_branch = "work"
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/scripts/audit_readiness_validation.py
+++ b/scripts/audit_readiness_validation.py
@@ -4,7 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
-from generator.audit_bundle import validate_bundle
+from data.outputs.audit_bundle import validate_audit_bundle
 from generator.failure_emitter import FailureEmitter, FailureLabel
 
 
@@ -46,7 +46,7 @@ def main() -> int:
         return 1
 
     manifest = json.loads(args.manifest_path.read_text(encoding="utf-8"))
-    results = validate_bundle(manifest)
+    results = validate_audit_bundle(manifest)
     if results["status"] != "pass":
         emitter.emit(
             FailureLabel(


### PR DESCRIPTION
### Motivation
- Ensure the audit manifest includes benchmark-derived metrics and required fields (`timestamp`, entropy totals, verity mean, `checksum`) sourced from the benchmark log.
- Provide a reusable reference-loop orchestrator that wires orchestration, verity computation, and entropy budget checks for bounded recursion experiments.
- Expose helper APIs for entropy budget verification and verity computation so other components (CLI, promotion gates) can call a canonical implementation.
- Align CLI and packaging metadata so the `sswg` console entrypoint and audit bundle flow match the golden-path semantics.

### Description
- Added `data/outputs/audit_bundle.py` with `build_audit_bundle` and `validate_audit_bundle` that wrap `generator.audit_bundle`, enrich manifests with `timestamp`, `entropy_totals`, `verity_mean`, and a manifest `checksum`, and require a benchmark log input. 
- Introduced `generator/reference_loop.py` containing `run_reference_loop` and `ReferenceLoopResult`, wired to `ai_core.Orchestrator`, `ai_memory.BenchmarkEvolution`/`EntropyController`, and `ai_evaluation.compute_verity`.
- Added `verify_entropy_budget` to `ai_memory/entropy_controller.py` and `compute_verity` to `ai_evaluation/verity_tensor.py`, and exported both from their packages (`ai_memory`, `ai_evaluation`).
- Updated CLI and scripts to use the new audit bundle module and benchmark log argument: `cli/cli.py` now passes `--benchmark-log`, and `scripts/audit_bundle_builder.py`, `scripts/run_promotion_readiness.py`, and `scripts/audit_readiness_validation.py` call the new functions and validate the benchmark log; added `data/outputs/__init__.py` and adjusted `.gitignore`.
- Bumped project versioning and packaging metadata to `1.3.0+mvm`, added PEP 621 fields and a `[build-system]` block in `pyproject.toml`, and added a `console_scripts` entry `sswg = cli.cli:main` in `config/setup.py` to align the installed CLI name.

### Testing
- No automated tests were executed on this change set (no test run was requested).
- Local repository changes were staged and committed successfully (`git commit` completed).
