### PR TITLE
Add deterministic_required to validate phase schema

### DIFF
--- a/schemas/pdl-phases/validate.json
+++ b/schemas/pdl-phases/validate.json
@@ -15,11 +15,12 @@
               "type": "object",
               "additionalProperties": false,
               "properties": {
+                "deterministic_required": { "type": "boolean", "const": true },
                 "schema_validation_required": { "type": "boolean", "const": true },
                 "invariants_required": { "type": "boolean", "const": true },
                 "bijectivity_check_required": { "type": "boolean" }
               },
-              "required": ["schema_validation_required", "invariants_required"]
+              "required": ["deterministic_required", "schema_validation_required", "invariants_required"]
             }
           },
           "required": ["constraints"]


### PR DESCRIPTION
### Motivation
- Align the `validate` phase schema with existing PDL files which declare `deterministic_required` in their `constraints` sections. 
- Ensure the `validate` phase enforces determinism as a required invariant for mvm compliance. 
- Keep schema strictness so only declared constraint fields are permitted by preserving `additionalProperties: false`. 

### Description
- Updated `schemas/pdl-phases/validate.json` to add the `constraints.properties.deterministic_required` field as `{ "type": "boolean", "const": true }`.
- Added `deterministic_required` to the `constraints.required` array so it is mandatory alongside `schema_validation_required` and `invariants_required`.
- Retained `additionalProperties: false` in the `constraints` object so only declared constraint keys are allowed.

### Testing
- No automated tests were executed as part of this change.
