### PR TITLE
Add governance source validation gate

### DIFF
--- a/ai_cores/governance_core.py
+++ b/ai_cores/governance_core.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+ai_cores/governance_core.py — Governance document detection utilities.
+
+Provides deterministic scanning helpers for governance-like documents.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import re
+from pathlib import Path
+from typing import Iterable, List
+
+__all__ = [
+    "GOVERNANCE_FILENAME_PATTERNS",
+    "GOVERNANCE_TOKEN_PATTERNS",
+    "find_governance_like_files",
+    "is_governance_like",
+]
+
+GOVERNANCE_FILENAME_PATTERNS = [
+    "AGENTS.md",
+    "TERMINOLOGY.md",
+    "*CONSTITUTION*.md",
+    "*POLICY*.md",
+    "*GOVERNANCE*.md",
+    "*GUARANTEE*.md",
+    "*ARCHITECTURE*.md",
+    "*REFERENCES*.md",
+]
+
+GOVERNANCE_TOKEN_PATTERNS = [
+    "MUST",
+    "SHALL",
+    "invariant",
+    "governance",
+    "validator",
+    "enforcement",
+    "fail_closed",
+]
+
+EXCLUDED_DIRS = {".git", "directive_core", "legacy_governance"}
+
+
+def _matches_filename(name: str) -> bool:
+    return any(fnmatch.fnmatch(name, pattern) for pattern in GOVERNANCE_FILENAME_PATTERNS)
+
+
+def _matches_tokens(payload: str) -> bool:
+    for token in GOVERNANCE_TOKEN_PATTERNS:
+        if re.search(rf"\b{re.escape(token)}\b", payload, flags=re.IGNORECASE):
+            return True
+    return False
+
+
+def is_governance_like(path: Path) -> bool:
+    """Return True when the file meets governance-like criteria."""
+    if _matches_filename(path.name):
+        return True
+    try:
+        payload = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return False
+    return _matches_tokens(payload)
+
+
+def _is_excluded(path: Path, repo_root: Path) -> bool:
+    try:
+        relative = path.relative_to(repo_root)
+    except ValueError:
+        return True
+    return any(part in EXCLUDED_DIRS for part in relative.parts)
+
+
+def find_governance_like_files(repo_root: Path) -> List[Path]:
+    """Return governance-like files outside directive_core/docs."""
+    repo_root = repo_root.resolve()
+    matches: List[Path] = []
+    for path in repo_root.rglob("*"):
+        if not path.is_file():
+            continue
+        if _is_excluded(path, repo_root):
+            continue
+        if is_governance_like(path):
+            matches.append(path.relative_to(repo_root))
+    return sorted(matches)

--- a/generator/failure_emitter.py
+++ b/generator/failure_emitter.py
@@ -12,8 +12,11 @@ from generator.hashing import hash_data
 from generator.sanitizer import sanitize_payload
 
 ALLOWED_FAILURE_TYPES = {
+    "deprecation_violation",
     "deterministic_failure",
+    "governance_violation",
     "schema_failure",
+    "tooling_reference_violation",
     "io_failure",
     "tool_mismatch",
     "reproducibility_failure",
@@ -27,6 +30,7 @@ class FailureLabel:  # pylint: disable=invalid-name
     Type: str
     message: str
     phase_id: str
+    path: str = "<unspecified>"
     evidence: Optional[Dict[str, Any]] = None
 
     def as_dict(self) -> Dict[str, Any]:
@@ -35,6 +39,7 @@ class FailureLabel:  # pylint: disable=invalid-name
             "Type": self.Type,
             "message": self.message,
             "phase_id": self.phase_id,
+            "path": self.path,
         }
         if self.evidence is not None:
             payload["evidence"] = self.evidence
@@ -49,6 +54,8 @@ def validate_failure_label(label: FailureLabel) -> None:
         raise ValueError("Failure label message must be non-empty")
     if not label.phase_id:
         raise ValueError("Failure label phase_id must be non-empty")
+    if not label.path.strip():
+        raise ValueError("Failure label path must be non-empty")
 
 
 class FailureEmitter:  # pylint: disable=too-few-public-methods
@@ -72,6 +79,7 @@ class FailureEmitter:  # pylint: disable=too-few-public-methods
             Type=label.Type,
             message=label.message,
             phase_id=label.phase_id,
+            path=label.path,
             evidence=sanitize_payload(label.evidence) if label.evidence else None,
         )
         payload: Dict[str, Any] = {

--- a/scripts/validate_governance_source_location.py
+++ b/scripts/validate_governance_source_location.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ai_cores.cli_arg_parser_core import build_parser, parse_args
+from ai_cores.governance_core import find_governance_like_files
+from generator.failure_emitter import FailureEmitter, FailureLabel
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = build_parser("Validate governance document source locations.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path("."),
+        help="Repository root to scan.",
+    )
+    parser.add_argument(
+        "--run-id",
+        type=str,
+        default="governance-source-validation",
+        help="Run identifier.",
+    )
+    return parse_args(parser)
+
+
+def main() -> int:
+    args = _parse_args()
+    repo_root = args.repo_root
+    violations = find_governance_like_files(repo_root)
+    if violations:
+        failure = FailureLabel(
+            Type="governance_violation",
+            message="Governance-like document found outside directive_core/docs",
+            phase_id="governance_source_validation",
+            path=str(violations[0]),
+        )
+        FailureEmitter(Path("artifacts/governance/failures")).emit(
+            failure, run_id=args.run_id
+        )
+        print("Governance source validation failed")
+        return 1
+
+    print("Governance source validation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
### Motivation
- Enforce the invariant that governance-like documents must reside only in `directive_core/docs/` as required by the validator taxonomy. 
- Ensure violations are emitted as structured, machine-readable failure labels of type `governance_violation`. 
- Extend the canonical failure label schema to include an explicit `path` field and new taxonomy types required by policy. 
- Provide reusable detection utilities to make governance-location checks deterministic and reusable across scripts.

### Description
- Add `ai_cores/governance_core.py` which implements filename- and token-based detection and the helper `find_governance_like_files`. 
- Add `scripts/validate_governance_source_location.py` which scans the repo (excluding configured paths) and emits a `FailureLabel` with `Type: "governance_violation"` and `phase_id: "governance_source_validation"` for the first violation found. 
- Update `generator/failure_emitter.py` to include a required `path` field in `FailureLabel` payloads and add new allowed failure types `governance_violation`, `tooling_reference_violation`, and `deprecation_violation`. 
- Emitted failure payloads continue to be written via `FailureEmitter` into the artifacts directory following existing semantics.
